### PR TITLE
Bk/fix jumpy scrolling after rotation #9

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.0.0'
+  s.version  = '1.0.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/Types/ElementLocationFramePairs.swift
+++ b/MagazineLayout/LayoutCore/Types/ElementLocationFramePairs.swift
@@ -127,11 +127,7 @@ final class ElementLocationFramePair {
 
 extension ElementLocationFramePair: Equatable {
 
-  static func ==(
-    lhs: ElementLocationFramePair,
-    rhs: ElementLocationFramePair)
-    -> Bool
-  {
+  static func == (lhs: ElementLocationFramePair, rhs: ElementLocationFramePair) -> Bool {
     return lhs.elementLocation == rhs.elementLocation && lhs.frame == rhs.frame
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -167,6 +167,14 @@ public final class MagazineLayout: UICollectionViewLayout {
       itemLayoutAttributes = newItemLayoutAttributes
     }
 
+    if
+      prepareActions.contains(.recreateSectionModels) ||
+      prepareActions.contains(.updateLayoutMetrics)
+    {
+      lastSizedElementMinY = nil
+      lastSizedElementPreferredHeight = nil
+    }
+
     prepareActions = []
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -550,9 +550,36 @@ public final class MagazineLayout: UICollectionViewLayout {
       assertionFailure("`MagazineLayout` does not support decoration views")
     }
 
+    let currentElementY = originalAttributes.frame.minY
+
     let context = super.invalidationContext(
       forPreferredLayoutAttributes: preferredAttributes,
       withOriginalAttributes: originalAttributes) as! MagazineLayoutInvalidationContext
+
+    // If layout information is discarded above our current scroll position (on rotation, for
+    // example), we need to compensate for preferred size changes to items as we're scrolling up,
+    // otherwise, the collection view will appear to jump each time an element is sized.
+    // Since size adjustments can occur for multiple items in the same soon-to-be-visible row, we
+    // need to account for this by considering the preferred height for previously sized elements in
+    // the same row so that we only adjust the content offset by the exact amount needed to create
+    // smooth scrolling.
+    let isScrolling = currentCollectionView.isDragging || currentCollectionView.isDecelerating
+    let isSizingElementAboveTopEdge = originalAttributes.frame.minY < currentCollectionView.contentOffset.y
+
+    if isScrolling && isSizingElementAboveTopEdge {
+      let isSameRowAsLastSizedElement = lastSizedElementMinY == currentElementY
+      if isSameRowAsLastSizedElement {
+        let lastSizedElementPreferredHeight = self.lastSizedElementPreferredHeight ?? 0
+        if preferredAttributes.size.height > lastSizedElementPreferredHeight {
+          context.contentOffsetAdjustment.y = preferredAttributes.size.height - lastSizedElementPreferredHeight
+        }
+      } else {
+        context.contentOffsetAdjustment.y = preferredAttributes.size.height - originalAttributes.size.height
+      }
+    }
+
+    lastSizedElementMinY = currentElementY
+    lastSizedElementPreferredHeight = preferredAttributes.size.height
 
     context.invalidateLayoutMetrics = false
 
@@ -601,6 +628,12 @@ public final class MagazineLayout: UICollectionViewLayout {
 
   private let modelState = ModelState()
   private var cachedCollectionViewWidth: CGFloat?
+
+  // These properties are used to prevent scroll jumpiness due to self-sizing after rotation; see
+  // comment in `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)` for more
+  // details.
+  private var lastSizedElementMinY: CGFloat?
+  private var lastSizedElementPreferredHeight: CGFloat?
 
   // The current layout attributes after batch updates have started and after they finish
   private var headerLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()

--- a/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
@@ -54,7 +54,7 @@ public enum MagazineLayoutHeaderHeightMode {
 
 extension MagazineLayoutHeaderHeightMode: Equatable {
 
-  public static func ==(
+  public static func == (
     lhs: MagazineLayoutHeaderHeightMode,
     rhs: MagazineLayoutHeaderHeightMode)
     -> Bool

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -92,7 +92,7 @@ public enum MagazineLayoutItemWidthMode {
 
 extension MagazineLayoutItemWidthMode: Equatable {
 
-  public static func ==(
+  public static func == (
     lhs: MagazineLayoutItemWidthMode,
     rhs: MagazineLayoutItemWidthMode)
     -> Bool
@@ -145,7 +145,7 @@ public enum MagazineLayoutItemHeightMode {
 
 extension MagazineLayoutItemHeightMode: Equatable {
 
-  public static func ==(
+  public static func == (
     lhs: MagazineLayoutItemHeightMode,
     rhs: MagazineLayoutItemHeightMode)
     -> Bool


### PR DESCRIPTION
## Details
This fixes jumpy scrolling when using self-sizing and rotating the screen. 

The root problem is that on rotation, we discard calculated layout information for elements in our collection view, since after rotation, we no longer know how tall elements will be given the new available width. Since we throw out layout information for all elements, if the user scrolls up after rotating the screen, we'll receive preferred attributes for elements above the top edge of the collection view, resulting in visible elements below the newly sized elements appearing to jump as preferred heights come in.

To fix the visual jumpiness, we need to adjust our content offset to compensate for any visible element offsetting due to receiving preferred attributes for elements above out current scroll position. The correct place to do this is in `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)`.

![ezgif-2-1b275f73aa47](https://user-images.githubusercontent.com/746571/50716020-8f4c5900-1034-11e9-800d-3c4b0b289f3c.gif)

## Related Issue

https://github.com/airbnb/MagazineLayout/issues/9

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

I tested several scenarios in the included example project.
- Top content inset of +100
- Top content inset of -100
- Top content inset of 0

Each time, I scrolled to the bottom, rotated the simulator, then scrolled to the top, ensuring that no jumpiness occurs and that the expected new code paths are hit.

I also tested the Airbnb app to ensure that various screens behave correctly / better.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.