### PR TITLE
Take safe area insets into account

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.0.1'
+  s.version  = '1.2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
+++ b/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
@@ -26,9 +26,15 @@ struct MagazineLayoutSectionMetrics: Equatable {
     layout: UICollectionViewLayout,
     delegate: UICollectionViewDelegateMagazineLayout)
   {
-    width = collectionView.bounds.width -
-      collectionView.contentInset.left -
-      collectionView.contentInset.right
+    if #available(iOS 11.0, *) {
+      width = collectionView.bounds.width -
+        collectionView.adjustedContentInset.left -
+        collectionView.adjustedContentInset.right
+    } else {
+      width = collectionView.bounds.width -
+        collectionView.contentInset.left -
+        collectionView.contentInset.right
+    }
     verticalSpacing = delegate.collectionView(
       collectionView,
       layout: layout,

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -39,7 +39,12 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     let width: CGFloat
     if let collectionView = collectionView {
-      let contentInset = collectionView.contentInset
+      let contentInset: UIEdgeInsets
+      if #available(iOS 11.0, *) {
+        contentInset = collectionView.adjustedContentInset
+      } else {
+        contentInset = collectionView.contentInset
+      }
       width = collectionView.bounds.width - contentInset.left - contentInset.right
     } else {
       width = 0

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -49,7 +49,9 @@ public enum MagazineLayoutItemWidthMode {
   ///
   /// Use this width mode to create lists of items.
   /// `respectsHorizontalInsets` specifies whether the item should be edge-to-edge in the collection
-  /// view, or if it should be inset by `contentInset.left` and `contentInset.right`.
+  /// view, or if it should be inset by `contentInset.left` and `contentInset.right`. On iOS 11 and
+  /// higher this will also take the safe area insets into account by insetting the item by
+  /// `adjustedContentInset.left` and `adjustedContentInset.right`.
   case fullWidth(respectsHorizontalInsets: Bool)
 
   /// Fractional width items will take up `1/divisor` of the available width for a given row of
@@ -60,7 +62,9 @@ public enum MagazineLayoutItemWidthMode {
   /// `divisor` of `2`, `3`, `4`, or `5`, respectively.
   ///
   /// Fractional width items respect `contentInset.left` and `contentInset.right`, and are affected
-  /// by the horizontal spacing specified for the section in which they're contained.
+  /// by the horizontal spacing specified for the section in which they're contained. On iOS 11 and
+  /// higher they will also take the safe area insets into account if the collection view's
+  /// `contentInsetAdjustmentBehavior` property is set to a value that respects the safe area.
   ///
   /// - Warning: `divisor` must be greater than `0`. Specifying `0` as the `divisor` is a programmer
   /// error and **will result in a runtime crash**.

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -50,7 +50,7 @@ public enum MagazineLayoutItemWidthMode {
   /// Use this width mode to create lists of items.
   /// `respectsHorizontalInsets` specifies whether the item should be edge-to-edge in the collection
   /// view, or if it should be inset by `contentInset.left` and `contentInset.right`. On iOS 11 and
-  /// higher this will also take the safe area insets into account by insetting the item by
+  /// higher, this will also take the safe area insets into account by insetting the item by
   /// `adjustedContentInset.left` and `adjustedContentInset.right`.
   case fullWidth(respectsHorizontalInsets: Bool)
 
@@ -63,7 +63,7 @@ public enum MagazineLayoutItemWidthMode {
   ///
   /// Fractional width items respect `contentInset.left` and `contentInset.right`, and are affected
   /// by the horizontal spacing specified for the section in which they're contained. On iOS 11 and
-  /// higher they will also take the safe area insets into account if the collection view's
+  /// higher, they will also take the safe area insets into account if the collection view's
   /// `contentInsetAdjustmentBehavior` property is set to a value that respects the safe area.
   ///
   /// - Warning: `divisor` must be greater than `0`. Specifying `0` as the `divisor` is a programmer


### PR DESCRIPTION
## Details

This PR shows a possible solution to take the safe area insets into account when calculating the available content width for items in the layout. It also updates some comments to make it clear that the safe area insets are taken into account.

## Related Issue

#13 

## Motivation and Context

If the content insets of the collection view are too small content might be hidden behind the notch or get clipped on the right side if certain iPhones are held in landscape.

## How Has This Been Tested

I ran the example project on the iPhone X Simulator in landscape mode.

## Types of changes

Note: Because many collection view's have the `contentInsetAdjustmentBehavior` set to a value that respects the safe area I think this change might break some layouts.

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.