### PR TITLE
Expose MagazineLayout.Default enum as public (#10)

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.2.0'
+  s.version  = '1.2.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/Types/MagazineLayout+Default.swift
+++ b/MagazineLayout/LayoutCore/Types/MagazineLayout+Default.swift
@@ -18,7 +18,7 @@ import UIKit
 extension MagazineLayout {
 
   /// Constants for layout sizing and spacing defaults.
-  enum Default {
+  public enum Default {
 
     static let ItemSizeMode = MagazineLayoutItemSizeMode(
       widthMode: .fullWidth(respectsHorizontalInsets: true),


### PR DESCRIPTION
## Details

While I was building an RxSwift extension for MagazineLayout (which can be discussed in a different topic), I needed to provide sensible defaults for the cases when a forwarding delegate was not defined. Those defaults have already being defined by the lib in MagazineLayout.Default, but they are not visible outside the library.

Since that enum doesn't expose any internal implementation details, it would be helpful to mark it as public

## Related Issue

Fixes #10 

## Motivation and Context



## How Has This Been Tested

N/A

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.