### PR TITLE
Expose MagazineLayout.Default enum as public (#10)

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.2.0'
+  s.version  = '1.2.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 				93A1C01A21ACED0100DED67D /* MagazineLayoutHeaderVisibilityMode.swift */,
 				93A1C01621ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift */,
 				93A1C01721ACED0100DED67D /* MagazineLayout+SupplementaryViewKinds.swift */,
+				93A1C02021ACED0100DED67D /* MagazineLayout+Default.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -186,7 +187,6 @@
 		93A1C01F21ACED0100DED67D /* Types */ = {
 			isa = PBXGroup;
 			children = (
-				93A1C02021ACED0100DED67D /* MagazineLayout+Default.swift */,
 				93A1C02221ACED0100DED67D /* MagazineLayoutSectionMetrics.swift */,
 				93A1C02621ACED0100DED67D /* MagazineLayoutItemWidthMode+WidthDivisor.swift */,
 				93A1C02321ACED0100DED67D /* CollectionViewUpdateItem.swift */,

--- a/MagazineLayout/Public/Types/MagazineLayout+Default.swift
+++ b/MagazineLayout/Public/Types/MagazineLayout+Default.swift
@@ -18,19 +18,19 @@ import UIKit
 extension MagazineLayout {
 
   /// Constants for layout sizing and spacing defaults.
-  enum Default {
+  public enum Default {
 
-    static let ItemSizeMode = MagazineLayoutItemSizeMode(
+    public static let ItemSizeMode = MagazineLayoutItemSizeMode(
       widthMode: .fullWidth(respectsHorizontalInsets: true),
       heightMode: MagazineLayoutItemHeightMode.static(height: ItemHeight))
-    static let HeaderVisibilityMode = MagazineLayoutHeaderVisibilityMode.hidden
-    static let BackgroundVisibilityMode = MagazineLayoutBackgroundVisibilityMode.hidden
+    public static let HeaderVisibilityMode = MagazineLayoutHeaderVisibilityMode.hidden
+    public static let BackgroundVisibilityMode = MagazineLayoutBackgroundVisibilityMode.hidden
 
-    static let ItemHeight: CGFloat = 150
-    static let HeaderHeight: CGFloat = 44
-    static let VerticalSpacing: CGFloat = 0
-    static let HorizontalSpacing: CGFloat = 0
-    static let ItemInsets: UIEdgeInsets = .zero
+    public static let ItemHeight: CGFloat = 150
+    public static let HeaderHeight: CGFloat = 44
+    public static let VerticalSpacing: CGFloat = 0
+    public static let HorizontalSpacing: CGFloat = 0
+    public static let ItemInsets: UIEdgeInsets = .zero
 
   }
 


### PR DESCRIPTION
## Details

While I was building an RxSwift extension for MagazineLayout (which can be discussed in a different topic), I needed to provide sensible defaults for the cases when a forwarding delegate was not defined. Those defaults have already being defined by the lib in MagazineLayout.Default, but they are not visible outside the library.

Since that enum doesn't expose any internal implementation details, it would be helpful to mark it as public

## Related Issue

Fixes #10 

## Motivation and Context



## How Has This Been Tested

N/A

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.