### PR TITLE
Introduce a workaround for radar 46865293

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.2.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.2.1'
+  s.version  = '1.2.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -45,7 +45,16 @@ public final class MagazineLayout: UICollectionViewLayout {
       } else {
         contentInset = collectionView.contentInset
       }
-      width = collectionView.bounds.width - contentInset.left - contentInset.right
+
+      // This is a workaround for `layoutAttributesForElementsInRect:` not getting invoked enough
+      // times if `collectionViewContentSize.width` is not smaller than the width of the collection
+      // view, minus horizontal insets. This results in visual defects when performing batch
+      // updates. To work around this, we subtract 0.0001 from our content size width calculation -
+      // this small decrease in `collectionViewContentSize.width` is enough to workaround the
+      // incorrect, internal collection view `CGRect` checks, without introducing any visual
+      // difference for elements in the collection view.
+      // See https://openradar.appspot.com/radar?id=5025850143539200 for more details.
+      width = collectionView.bounds.width - contentInset.left - contentInset.right - 0.0001
     } else {
       width = 0
     }


### PR DESCRIPTION
## Details
This introduces a workaround for this `UICollectionView` bug: https://openradar.appspot.com/radar?id=5025850143539200

Batch update animations are glitchy / can put the layout in an incorrect state if `collectionViewContentSize.width` is >= `the collection view's width, minus its horizontal content insets`. To work around this bug, we can subtract a very small number from our `collectionViewContentSize.width` calculation, guaranteeing that it will be smaller than `the collection view's width, minus its horizontal content insets`. The value that we subtract is large enough to satisfy the buggy, internal `CGRect` comparisons, but small enough to not introduce any visual differences for elements in the collection view.

## Related Issue
https://github.com/airbnb/MagazineLayout/issues/27

## Motivation and Context
Fixes animation glitches that the community and Airbnb employees have encountered.

## How Has This Been Tested
- Tested on iPhone and iPad simulator (iOS 10, 11, and 12) and real device (iPhone XS). No visual defect occurs during or after animations if the fix is present.
- Confirmed no misalignment issues using the simulator tool to highlight misalignments
- Compared 2 screenshots using a visual diffing tool to confirm no misalignment issues

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.