### PR TITLE
Bk/fix header sizing assertion

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.2.2'
+  s.version  = '1.2.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -119,7 +119,7 @@ final class ModelState {
       return sectionModels[indexPath.section].itemModel(atIndex: indexPath.item).sizeMode.heightMode
     }
 
-    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
+    switch updateContextForItemPreferredHeightUpdate(at: indexPath) {
     case .updatePreviousModels, .updatePreviousAndCurrentModels:
       return itemModelHeightModeDuringPreferredAttributesCheck(
         at: indexPath,
@@ -148,9 +148,7 @@ final class ModelState {
       return sectionModels[sectionIndex].headerModel?.heightMode
     }
 
-    let preferredHeightUpdateContext = preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
-      inSectionAtIndex: sectionIndex)
-    switch preferredHeightUpdateContext {
+    switch updateContextForSupplementaryViewPreferredHeightUpdate(inSectionAtIndex: sectionIndex) {
     case .updatePreviousModels, .updatePreviousAndCurrentModels:
       return headerModelHeightModeDuringPreferredAttributesCheck(
         atSectionIndex: sectionIndex,
@@ -179,7 +177,7 @@ final class ModelState {
       return sectionModels[indexPath.section].preferredHeightForItemModel(atIndex: indexPath.item)
     }
 
-    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
+    switch updateContextForItemPreferredHeightUpdate(at: indexPath) {
     case .updatePreviousModels, .updatePreviousAndCurrentModels:
       return itemModelPreferredHeightDuringPreferredAttributesCheck(
         at: indexPath,
@@ -381,7 +379,7 @@ final class ModelState {
         atIndex: indexPath.item)
     }
 
-    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
+    switch updateContextForItemPreferredHeightUpdate(at: indexPath) {
     case .updatePreviousModels:
       updateItemHeight(
         toPreferredHeight: preferredHeight,
@@ -423,9 +421,7 @@ final class ModelState {
       sectionModels[sectionIndex].updateHeaderHeight(toPreferredHeight: preferredHeight)
     }
 
-    let preferredHeightUpdateContext = preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
-      inSectionAtIndex: sectionIndex)
-    switch preferredHeightUpdateContext {
+    switch updateContextForSupplementaryViewPreferredHeightUpdate(inSectionAtIndex: sectionIndex) {
     case .updatePreviousModels:
       updateHeaderHeight(
         toPreferredHeight: preferredHeight,
@@ -611,7 +607,7 @@ final class ModelState {
     }
   }
 
-  private func preferredHeightUpdateContextForPreferredHeightUpdateToItem(
+  private func updateContextForItemPreferredHeightUpdate(
     at indexPath: IndexPath)
     -> ItemPreferredHeightUpdateContext
   {
@@ -664,7 +660,7 @@ final class ModelState {
     return .updateCurrentModels
   }
 
-  private func preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
+  private func updateContextForSupplementaryViewPreferredHeightUpdate(
     inSectionAtIndex sectionIndex: Int)
     -> SupplementaryViewPreferredHeightUpdateContext
   {

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -99,11 +99,11 @@ final class ModelState {
     return nil
   }
 
-  func itemModelHeightModeForPreferredAttributesCheck(
+  func itemModelHeightModeDuringPreferredAttributesCheck(
     at indexPath: IndexPath)
     -> MagazineLayoutItemHeightMode?
   {
-    func itemModelHeightModeForPreferredAttributesCheck(
+    func itemModelHeightModeDuringPreferredAttributesCheck(
       at indexPath: IndexPath,
       sectionModels: inout [SectionModel])
       -> MagazineLayoutItemHeightMode?
@@ -119,13 +119,13 @@ final class ModelState {
       return sectionModels[indexPath.section].itemModel(atIndex: indexPath.item).sizeMode.heightMode
     }
 
-    switch preferredHeightUpdateContext(forPreferredHeightUpdateToItemAt: indexPath) {
+    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
     case .updatePreviousModels, .updatePreviousAndCurrentModels:
-      return itemModelHeightModeForPreferredAttributesCheck(
+      return itemModelHeightModeDuringPreferredAttributesCheck(
         at: indexPath,
         sectionModels: &sectionModelsBeforeBatchUpdates)
     case .updateCurrentModels:
-      return itemModelHeightModeForPreferredAttributesCheck(
+      return itemModelHeightModeDuringPreferredAttributesCheck(
         at: indexPath,
         sectionModels: &currentSectionModels)
     }
@@ -135,12 +135,31 @@ final class ModelState {
     atSectionIndex sectionIndex: Int)
     -> MagazineLayoutHeaderHeightMode?
   {
-    guard sectionIndex < currentSectionModels.count else {
-      assertionFailure("Height mode for header at section index \(sectionIndex) is out of bounds")
-      return nil
+    func headerModelHeightModeDuringPreferredAttributesCheck(
+      atSectionIndex sectionIndex: Int,
+      sectionModels: inout [SectionModel])
+      -> MagazineLayoutHeaderHeightMode?
+    {
+      guard sectionIndex < sectionModels.count else {
+        assertionFailure("Height mode for header at section index \(sectionIndex) is out of bounds")
+        return nil
+      }
+
+      return sectionModels[sectionIndex].headerModel?.heightMode
     }
 
-    return currentSectionModels[sectionIndex].headerModel?.heightMode
+    let preferredHeightUpdateContext = preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
+      inSectionAtIndex: sectionIndex)
+    switch preferredHeightUpdateContext {
+    case .updatePreviousModels, .updatePreviousAndCurrentModels:
+      return headerModelHeightModeDuringPreferredAttributesCheck(
+        atSectionIndex: sectionIndex,
+        sectionModels: &sectionModelsBeforeBatchUpdates)
+    case .updateCurrentModels:
+      return headerModelHeightModeDuringPreferredAttributesCheck(
+        atSectionIndex: sectionIndex,
+        sectionModels: &currentSectionModels)
+    }
   }
 
   func itemModelPreferredHeightDuringPreferredAttributesCheck(at indexPath: IndexPath) -> CGFloat? {
@@ -160,7 +179,7 @@ final class ModelState {
       return sectionModels[indexPath.section].preferredHeightForItemModel(atIndex: indexPath.item)
     }
 
-    switch preferredHeightUpdateContext(forPreferredHeightUpdateToItemAt: indexPath) {
+    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
     case .updatePreviousModels, .updatePreviousAndCurrentModels:
       return itemModelPreferredHeightDuringPreferredAttributesCheck(
         at: indexPath,
@@ -340,23 +359,6 @@ final class ModelState {
     return backgroundFrame
   }
 
-  func updateMetrics(
-    to sectionMetrics: MagazineLayoutSectionMetrics,
-    forSectionAtIndex sectionIndex: Int)
-  {
-    currentSectionModels[sectionIndex].updateMetrics(to: sectionMetrics)
-
-    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
-  }
-
-  func updateItemSizeMode(to sizeMode: MagazineLayoutItemSizeMode, forItemAt indexPath: IndexPath) {
-    currentSectionModels[indexPath.section].updateItemSizeMode(
-      to: sizeMode,
-      atIndex: indexPath.item)
-
-    invalidateSectionMaxYsCacheForSectionIndices(startingAt: indexPath.section)
-  }
-
   func updateItemHeight(
     toPreferredHeight preferredHeight: CGFloat,
     forItemAt indexPath: IndexPath)
@@ -377,11 +379,9 @@ final class ModelState {
       sectionModels[indexPath.section].updateItemHeight(
         toPreferredHeight: preferredHeight,
         atIndex: indexPath.item)
-
-      invalidateSectionMaxYsCacheForSectionIndices(startingAt: indexPath.section)
     }
 
-    switch preferredHeightUpdateContext(forPreferredHeightUpdateToItemAt: indexPath) {
+    switch preferredHeightUpdateContextForPreferredHeightUpdateToItem(at: indexPath) {
     case .updatePreviousModels:
       updateItemHeight(
         toPreferredHeight: preferredHeight,
@@ -392,6 +392,7 @@ final class ModelState {
         toPreferredHeight: preferredHeight,
         forItemAt: indexPath,
         sectionModels: &currentSectionModels)
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: indexPath.section)
     case let .updatePreviousAndCurrentModels(previousIndexPath, currentIndexPath):
       updateItemHeight(
         toPreferredHeight: preferredHeight,
@@ -401,7 +402,69 @@ final class ModelState {
         toPreferredHeight: preferredHeight,
         forItemAt: currentIndexPath,
         sectionModels: &currentSectionModels)
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: currentIndexPath.section)
     }
+  }
+
+  func updateHeaderHeight(
+    toPreferredHeight preferredHeight: CGFloat,
+    forSectionAtIndex sectionIndex: Int)
+  {
+    func updateHeaderHeight(
+      toPreferredHeight preferredHeight: CGFloat,
+      forSectionAtIndex sectionIndex: Int,
+      sectionModels: inout [SectionModel])
+    {
+      guard sectionIndex < sectionModels.count else {
+        assertionFailure("Updating the preferred height for a header model at section index \(sectionIndex) is out of bounds")
+        return
+      }
+
+      sectionModels[sectionIndex].updateHeaderHeight(toPreferredHeight: preferredHeight)
+    }
+
+    let preferredHeightUpdateContext = preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
+      inSectionAtIndex: sectionIndex)
+    switch preferredHeightUpdateContext {
+    case .updatePreviousModels:
+      updateHeaderHeight(
+        toPreferredHeight: preferredHeight,
+        forSectionAtIndex: sectionIndex,
+        sectionModels: &sectionModelsBeforeBatchUpdates)
+    case .updateCurrentModels:
+      updateHeaderHeight(
+        toPreferredHeight: preferredHeight,
+        forSectionAtIndex: sectionIndex,
+        sectionModels: &currentSectionModels)
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+    case let .updatePreviousAndCurrentModels(previousSectionIndex, currentSectionIndex):
+      updateHeaderHeight(
+        toPreferredHeight: preferredHeight,
+        forSectionAtIndex: previousSectionIndex,
+        sectionModels: &sectionModelsBeforeBatchUpdates)
+      updateHeaderHeight(
+        toPreferredHeight: preferredHeight,
+        forSectionAtIndex: currentSectionIndex,
+        sectionModels: &currentSectionModels)
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: currentSectionIndex)
+    }
+  }
+
+  func updateMetrics(
+    to sectionMetrics: MagazineLayoutSectionMetrics,
+    forSectionAtIndex sectionIndex: Int)
+  {
+    currentSectionModels[sectionIndex].updateMetrics(to: sectionMetrics)
+
+    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+  }
+
+  func updateItemSizeMode(to sizeMode: MagazineLayoutItemSizeMode, forItemAt indexPath: IndexPath) {
+    currentSectionModels[indexPath.section].updateItemSizeMode(
+      to: sizeMode,
+      atIndex: indexPath.item)
+
+    invalidateSectionMaxYsCacheForSectionIndices(startingAt: indexPath.section)
   }
 
   func setHeader(_ headerModel: HeaderModel, forSectionAtIndex sectionIndex: Int) {
@@ -412,20 +475,6 @@ final class ModelState {
 
   func removeHeader(forSectionAtIndex sectionIndex: Int) {
     currentSectionModels[sectionIndex].removeHeader()
-
-    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
-  }
-
-  func updateHeaderHeight(
-    toPreferredHeight preferredHeight: CGFloat,
-    forSectionAtIndex sectionIndex: Int)
-  {
-    guard sectionIndex < currentSectionModels.count else {
-      assertionFailure("Updating the preferred height for a header model at section index \(sectionIndex) is out of bounds")
-      return
-    }
-
-    currentSectionModels[sectionIndex].updateHeaderHeight(toPreferredHeight: preferredHeight)
 
     invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
   }
@@ -526,10 +575,16 @@ final class ModelState {
 
   // MARK: Private
 
-  private enum PreferredHeightUpdateContext {
+  private enum ItemPreferredHeightUpdateContext {
     case updatePreviousModels
     case updateCurrentModels
     case updatePreviousAndCurrentModels(previousIndexPath: IndexPath, currentIndexPath: IndexPath)
+  }
+
+  private enum SupplementaryViewPreferredHeightUpdateContext {
+    case updatePreviousModels
+    case updateCurrentModels
+    case updatePreviousAndCurrentModels(previousSectionIndex: Int, currentSectionIndex: Int)
   }
 
   private var currentSectionModels = [SectionModel]()
@@ -556,9 +611,9 @@ final class ModelState {
     }
   }
 
-  private func preferredHeightUpdateContext(
-    forPreferredHeightUpdateToItemAt indexPath: IndexPath)
-    -> PreferredHeightUpdateContext
+  private func preferredHeightUpdateContextForPreferredHeightUpdateToItem(
+    at indexPath: IndexPath)
+    -> ItemPreferredHeightUpdateContext
   {
     // iOS 12 fixes an issue that causes `UICollectionView` to provide preferred attributes for old,
     // invalid item index paths. This happens when an item is deleted, causing an off-screen,
@@ -595,9 +650,7 @@ final class ModelState {
         indexPath.section < sectionModelsBeforeBatchUpdates.count,
         indexPath.item < sectionModelsBeforeBatchUpdates[indexPath.section].numberOfItems,
         let previousItemModelID = idForItemModel(at: indexPath, .beforeUpdates),
-        let currentIndexPath = indexPathForItemModel(
-          withID: previousItemModelID,
-          .afterUpdates)
+        let currentIndexPath = indexPathForItemModel(withID: previousItemModelID, .afterUpdates)
       {
         // If an item was moved, then it will have an ID in the section models before batch updates,
         // and that ID will match an index path in the current section models. In this scenario, we
@@ -605,6 +658,47 @@ final class ModelState {
         return .updatePreviousAndCurrentModels(
           previousIndexPath: indexPath,
           currentIndexPath: currentIndexPath)
+      }
+    }
+
+    return .updateCurrentModels
+  }
+
+  private func preferredHeightUpdateContextForPreferredHeightUpdateToSupplementaryView(
+    inSectionAtIndex sectionIndex: Int)
+    -> SupplementaryViewPreferredHeightUpdateContext
+  {
+    // An issue exists that causes `UICollectionView` to provide preferred attributes for old,
+    // invalid supplementary view index paths. This happens when a section is deleted, causing an
+    // off-screen, unsized supplementary view to slide up into view. At this point,
+    // `UICollectionView` sizes that supplementary view since it's now visible, but it provides the
+    // preferred attributes for the supplementary view's index path *before* the delete batch
+    // update.
+    // https://openradar.appspot.com/radar?id=5023315789873152
+    if !isPerformingBatchUpdates {
+      return .updateCurrentModels
+    } else {
+      if sectionIndicesToInsert.contains(sectionIndex) {
+        // If a section is being inserted, update the supplementary view's height in the section
+        // models after batch updates, since it won't exist in the previous section models.
+        return .updateCurrentModels
+      } else if sectionIndicesToDelete.contains(sectionIndex) {
+        // If a section is being deleted, update the supplementary view's height in the section
+        // models before batch updates, since it won't exist in the current section models.
+        return .updatePreviousModels
+      } else if
+        sectionIndex < sectionModelsBeforeBatchUpdates.count,
+        let previousSectionModelID = idForSectionModel(atIndex: sectionIndex, .beforeUpdates),
+        let currentSectionIndex = indexForSectionModel(
+          withID: previousSectionModelID,
+          .afterUpdates)
+      {
+        // If a supplementary view was moved, then it will have an ID in the section models before
+        // batch updates, and that ID will match a section index in the current section models. In
+        // this scenario, we want to update the section models from before and after batch updates.
+        return .updatePreviousAndCurrentModels(
+          previousSectionIndex: sectionIndex,
+          currentSectionIndex: currentSectionIndex)
       }
     }
 

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -71,7 +71,7 @@ struct SectionModel {
   }
 
   mutating func calculateFrameForHeader() -> CGRect? {
-    guard let headerModel = headerModel else { return nil }
+    guard headerModel != nil else { return nil }
 
     if
       let indexOfFirstInvalidatedItem = indexOfFirstInvalidatedItem,
@@ -80,21 +80,36 @@ struct SectionModel {
       recomputeItemPositionsIfNecessary()
     }
 
-    return CGRect(
-      origin: CGPoint(x: headerModel.originInSection.x, y: headerModel.originInSection.y),
-      size: headerModel.size)
+    // `headerModel` is a value type that might be mutated in `recomputeItemPositionsIfNecessary`,
+    // so we can't use a copy made before that code executes (for example, in a
+    // `guard let headerModel = headerModel else { ... }` at the top of this function).
+    if let headerModel = headerModel {
+      return CGRect(
+        origin: CGPoint(x: headerModel.originInSection.x, y: headerModel.originInSection.y),
+        size: headerModel.size)
+    } else {
+      return nil
+    }
   }
 
   mutating func calculateFrameForBackground() -> CGRect? {
-    guard let backgroundModel = backgroundModel else { return nil }
+    guard backgroundModel != nil else { return nil }
 
     if indexOfFirstInvalidatedItem != nil {
       recomputeItemPositionsIfNecessary()
     }
 
-    return CGRect(
-      origin: CGPoint(x: backgroundModel.originInSection.x, y: backgroundModel.originInSection.y),
-      size: backgroundModel.size)
+    // `backgroundModel` is a value type that might be mutated in
+    // `recomputeItemPositionsIfNecessary`, so we can't use a copy made before that code executes
+    // (for example, in a `guard let backgroundModel = backgroundModel else { ... }` at the top of
+    // this function).
+    if let backgroundModel = backgroundModel {
+      return CGRect(
+        origin: CGPoint(x: backgroundModel.originInSection.x, y: backgroundModel.originInSection.y),
+        size: backgroundModel.size)
+    } else {
+      return nil
+    }
   }
 
   mutating func calculateFrameForItem(atIndex itemIndex: Int) -> CGRect {

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -50,7 +50,7 @@ public final class MagazineLayout: UICollectionViewLayout {
       // times if `collectionViewContentSize.width` is not smaller than the width of the collection
       // view, minus horizontal insets. This results in visual defects when performing batch
       // updates. To work around this, we subtract 0.0001 from our content size width calculation -
-      // this small decrease in `collectionViewContentSize.width` is enough to workaround the
+      // this small decrease in `collectionViewContentSize.width` is enough to work around the
       // incorrect, internal collection view `CGRect` checks, without introducing any visual
       // difference for elements in the collection view.
       // See https://openradar.appspot.com/radar?id=5025850143539200 for more details.

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -524,7 +524,7 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     switch (preferredAttributes.representedElementCategory, preferredAttributes.representedElementKind) {
     case (.cell, nil):
-      let itemHeightMode = modelState.itemModelHeightModeForPreferredAttributesCheck(
+      let itemHeightMode = modelState.itemModelHeightModeDuringPreferredAttributesCheck(
         at: preferredAttributes.indexPath)
       switch itemHeightMode {
       case .some(.static):

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -176,9 +176,9 @@ public final class MagazineLayout: UICollectionViewLayout {
     }
 
     if prepareActions.contains(.lazilyCreateLayoutAttributes) {
+      itemLayoutAttributes = newItemLayoutAttributes
       headerLayoutAttributes = newHeaderLayoutAttributes
       backgroundLayoutAttributes = newBackgroundLayoutAttributes
-      itemLayoutAttributes = newItemLayoutAttributes
     }
 
     if
@@ -193,8 +193,6 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   override public func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
-    saveCurrentLayoutAttributesAsPreviousLayoutAttributes()
-
     var updates = [CollectionViewUpdate<SectionModel, ItemModel>]()
 
     for updateItem in updateItems {
@@ -272,22 +270,9 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   override public func finalizeCollectionViewUpdates() {
-    clearPreviousLayoutAttributes()
     modelState.clearInProgressBatchUpdateState()
 
     super.finalizeCollectionViewUpdates()
-  }
-
-  override public func prepare(forAnimatedBoundsChange oldBounds: CGRect) {
-    saveCurrentLayoutAttributesAsPreviousLayoutAttributes()
-
-    super.prepare(forAnimatedBoundsChange: oldBounds)
-  }
-
-  override public func finalizeAnimatedBoundsChange() {
-    clearPreviousLayoutAttributes()
-
-    super.finalizeAnimatedBoundsChange()
   }
 
   override public func layoutAttributesForElements(
@@ -407,9 +392,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         withID: movedItemID,
         .beforeUpdates)
     {
-      return previousLayoutAttributesForItem(at: initialIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      return previousLayoutAttributesForItem(at: initialIndexPath)
     } else {
-      return nil
+      return super.layoutAttributesForItem(at: itemIndexPath)
     }
   }
 
@@ -421,7 +406,7 @@ public final class MagazineLayout: UICollectionViewLayout {
       modelState.itemIndexPathsToDelete.contains(itemIndexPath) ||
       modelState.sectionIndicesToDelete.contains(itemIndexPath.section)
     {
-      let attributes = previousLayoutAttributesForItem(at: itemIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      let attributes = previousLayoutAttributesForItem(at: itemIndexPath)
       attributes?.alpha = 0
       return attributes
     } else if
@@ -432,7 +417,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     {
       return layoutAttributesForItem(at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
     } else {
-      return nil
+      return super.layoutAttributesForItem(at: itemIndexPath)
     }
   }
 
@@ -456,13 +441,11 @@ public final class MagazineLayout: UICollectionViewLayout {
         .beforeUpdates)
     {
       let initialIndexPath = IndexPath(item: 0, section: initialSectionIndex)
-      return previousLayoutAttributesForSupplementaryView(
-        ofKind: elementKind,
-        at: initialIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      return previousLayoutAttributesForSupplementaryView(ofKind: elementKind, at: initialIndexPath)
     } else {
-      return previousLayoutAttributesForSupplementaryView(
+      return super.initialLayoutAttributesForAppearingSupplementaryElement(
         ofKind: elementKind,
-        at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+        at: elementIndexPath)
     }
   }
 
@@ -474,7 +457,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     if modelState.sectionIndicesToDelete.contains(elementIndexPath.section) {
       let attributes = previousLayoutAttributesForSupplementaryView(
         ofKind: elementKind,
-        at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+        at: elementIndexPath)
       attributes?.alpha = 0
       return attributes
     } else if
@@ -490,9 +473,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         ofKind: elementKind,
         at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
     }  else {
-      return layoutAttributesForSupplementaryView(
-       ofKind: elementKind,
-        at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      return super.finalLayoutAttributesForDisappearingSupplementaryElement(
+        ofKind: elementKind,
+        at: elementIndexPath)
     }
   }
 
@@ -662,12 +645,6 @@ public final class MagazineLayout: UICollectionViewLayout {
   private var backgroundLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
   private var itemLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
 
-  // The previous layout attributes from before batch updates started
-  // Used in `initialLayoutAttributesForAppearing*` and `finalLayoutAttributesForDisappearing*`
-  private var previousItemLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
-  private var previousHeaderLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
-  private var previousBackgroundLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
-
   private struct PrepareActions: OptionSet {
     let rawValue: UInt
 
@@ -801,40 +778,19 @@ public final class MagazineLayout: UICollectionViewLayout {
     }
   }
 
-  private func saveCurrentLayoutAttributesAsPreviousLayoutAttributes() {
-    for (itemLocation, layoutAttributes) in itemLayoutAttributes {
-      let copiedLayoutAttributes = layoutAttributes.copy() as? MagazineLayoutCollectionViewLayoutAttributes
-      previousItemLayoutAttributes[itemLocation] = copiedLayoutAttributes
-    }
-
-    for (headerLocation, layoutAttributes) in headerLayoutAttributes {
-      let copiedLayoutAttributes = layoutAttributes.copy() as? MagazineLayoutCollectionViewLayoutAttributes
-      previousHeaderLayoutAttributes[headerLocation] = copiedLayoutAttributes
-    }
-
-    for (backgroundLocation, layoutAttributes) in backgroundLayoutAttributes {
-      let copiedLayoutAttributes = layoutAttributes.copy() as? MagazineLayoutCollectionViewLayoutAttributes
-      previousBackgroundLayoutAttributes[backgroundLocation] = copiedLayoutAttributes
-    }
-  }
-
-  private func clearPreviousLayoutAttributes() {
-    previousHeaderLayoutAttributes.removeAll()
-    previousBackgroundLayoutAttributes.removeAll()
-    previousItemLayoutAttributes.removeAll()
-  }
-
   private func previousLayoutAttributesForItem(
     at indexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
+    let layoutAttributes = MagazineLayoutCollectionViewLayoutAttributes(forCellWith: indexPath)
+
     guard modelState.isPerformingBatchUpdates else {
       // TODO(bryankeller): Look into whether this happens on iOS 10. It definitely does on iOS 9.
-      return nil
-    }
 
-    let itemLocation = ElementLocation(indexPath: indexPath)
-    let layoutAttributes = previousItemLayoutAttributes[itemLocation]
+      // Returning `nil` rather than default/frameless layout attributes causes internal exceptions
+      // within `UICollecionView`, which is why we don't return `nil` here.
+      return layoutAttributes
+    }
 
     guard
       indexPath.section < modelState.numberOfSections(.beforeUpdates),
@@ -850,7 +806,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       return layoutAttributes
     }
 
-    layoutAttributes?.frame = modelState.frameForItem(at: itemLocation, .beforeUpdates)
+    layoutAttributes.frame = modelState.frameForItem(
+      at: ElementLocation(indexPath: indexPath),
+      .beforeUpdates)
 
     return layoutAttributes
   }
@@ -860,34 +818,48 @@ public final class MagazineLayout: UICollectionViewLayout {
     at indexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
+    let layoutAttributes = MagazineLayoutCollectionViewLayoutAttributes(
+      forSupplementaryViewOfKind: elementKind,
+      with: indexPath)
+
     guard modelState.isPerformingBatchUpdates else {
       // TODO(bryankeller): Look into whether this happens on iOS 10. It definitely does on iOS 9.
-      return nil
+
+      // Returning `nil` rather than default/frameless layout attributes causes internal exceptions
+      // within `UICollecionView`, which is why we don't return `nil` here.
+      return layoutAttributes
     }
 
-    let elementLocation = ElementLocation(indexPath: indexPath)
+    guard indexPath.section < modelState.numberOfSections(.beforeUpdates) else {
+      // On iOS 9, `layoutAttributesForItem(at:)` can be invoked for an index path of a new
+      // supplementary view before the layout is notified of this new item (through either `prepare`
+      // or `prepare(forCollectionViewUpdates:)`). This seems to be fixed in iOS 10 and higher.
+      assertionFailure("`\(indexPath.section)` is out of bounds of the section models array.")
+
+      // Returning `nil` rather than default/frameless layout attributes causes internal exceptions
+      // within `UICollecionView`, which is why we don't return `nil` here.
+      return layoutAttributes
+    }
 
     if
       elementKind == MagazineLayout.SupplementaryViewKind.sectionHeader,
-      let headerLayoutAttributes = previousHeaderLayoutAttributes[elementLocation],
       let headerFrame = modelState.frameForHeader(
-        inSectionAtIndex: elementLocation.sectionIndex,
+        inSectionAtIndex: indexPath.section,
         .beforeUpdates)
     {
-      headerLayoutAttributes.frame = headerFrame
-      return headerLayoutAttributes
+      layoutAttributes.frame = headerFrame
     } else if
       elementKind == MagazineLayout.SupplementaryViewKind.sectionBackground,
-      let backgroundLayoutAttributes = previousBackgroundLayoutAttributes[elementLocation],
       let backgroundFrame = modelState.frameForBackground(
-        inSectionAtIndex: elementLocation.sectionIndex,
+        inSectionAtIndex: indexPath.section,
         .beforeUpdates)
     {
-      backgroundLayoutAttributes.frame = backgroundFrame
-      return backgroundLayoutAttributes
+      layoutAttributes.frame = backgroundFrame
     } else {
-      return nil
+      assertionFailure("\(elementKind) is not a valid supplementary view element kind.")
     }
+    
+    return layoutAttributes
   }
 
 }


### PR DESCRIPTION
## Details
This mainly fixes an issue that causes an assertionFailure to be hit when sizing a supplementary view. The root cause of the assert is a UICollectionView bug that causes the layout to receive preferred attributes for an unsized supplementary view that is sliding into view due to a delete above it. See https://openradar.appspot.com/radar?id=5023315789873152 for more details.

This is very similar to the same issue that existed for an unsized item sliding into view, for which I filed a radar last summer, which resulted in a fix being made for iOS 12.

I also made a few other improvements in this PR:
- Fixed a copy-on-write "bug" for supplementary views
- Did good grammar improvements
- Simplify the creation of previous layout attributes, which are only used for in-flight animations anyway


## Related Issue
https://openradar.appspot.com/radar?id=5023315789873152

## Motivation and Context
This adds a workaround for a UICollectionView bug, which will prevent people from running into assertions and potentially fix some production animation issues with headers.

## How Has This Been Tested
Tested in the sample app (iOS 12, iPhone 8) and in the Airbnb app (iOS 12, iPhone XS)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.