### PR TITLE
Bk/section inset support

### DIFF
--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -73,7 +73,6 @@ final class ViewController: UIViewController {
     collectionView.delegate = self
     collectionView.backgroundColor = .white
     collectionView.contentInsetAdjustmentBehavior = .always
-    collectionView.contentInset = UIEdgeInsets(top: 24, left: 0, bottom: 24, right: 0)
     return collectionView
   }()
 
@@ -251,7 +250,7 @@ final class ViewController: UIViewController {
           sizeMode: MagazineLayoutItemSizeMode(
             widthMode: .halfWidth,
             heightMode: .dynamicAndStretchToTallestItemInRow),
-          text: "and I'll match your height!",
+          text: "and I'll stretch to match your height.",
           color: Colors.orange),
       ],
       footerInfo: FooterInfo(
@@ -281,7 +280,7 @@ final class ViewController: UIViewController {
           sizeMode: MagazineLayoutItemSizeMode(
             widthMode: .fullWidth(respectsHorizontalInsets: true),
             heightMode: .dynamic),
-          text: "Tap tap the reload icon in the top left to...",
+          text: "Tap the reload icon in the top left to...",
           color: Colors.green),
         ItemInfo(
           sizeMode: MagazineLayoutItemSizeMode(
@@ -477,10 +476,19 @@ extension ViewController: UICollectionViewDelegateMagazineLayout {
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
+    insetsForSectionAtIndex index: Int)
+    -> UIEdgeInsets
+  {
+    return UIEdgeInsets(top: 24, left: 4, bottom: 24, right: 4)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
     insetsForItemsInSectionAtIndex index: Int)
     -> UIEdgeInsets
   {
-    return UIEdgeInsets(top: 24, left: 0, bottom: 24, right: 0)
+    return UIEdgeInsets(top: 24, left: 4, bottom: 24, right: 4)
   }
 
 }

--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.3.1'
+  s.version  = '1.4.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -350,11 +350,11 @@ struct SectionModel {
       return
     }
 
-    var currentY = CGFloat(0)
+    var currentY = metrics.sectionInsets.top
 
     // Section header calculation if rebuilding entire section
     if var newHeaderItemModel = headerModel, startingIndex == 0 {
-      newHeaderItemModel.originInSection = .zero
+      newHeaderItemModel.originInSection = CGPoint(x: metrics.sectionInsets.left, y: currentY)
       newHeaderItemModel.size.width = metrics.width
       newHeaderItemModel.size.height = newHeaderItemModel.preferredHeight ?? newHeaderItemModel.size.height
       headerModel = newHeaderItemModel
@@ -438,17 +438,17 @@ struct SectionModel {
       }
 
       let currentLeadingMargin: CGFloat
-      let availableWidth: CGFloat
+      let availableWidthForItems: CGFloat
       if itemModel.sizeMode.widthMode == .fullWidth(respectsHorizontalInsets: false) {
-        currentLeadingMargin = 0
-        availableWidth = metrics.width
+        currentLeadingMargin = metrics.sectionInsets.left
+        availableWidthForItems = metrics.width
       } else {
-        currentLeadingMargin = metrics.itemInsets.left
-        availableWidth = metrics.width - metrics.itemInsets.left - metrics.itemInsets.right
+        currentLeadingMargin = metrics.sectionInsets.left + metrics.itemInsets.left
+        availableWidthForItems = metrics.width - metrics.itemInsets.left - metrics.itemInsets.right
       }
 
       let totalSpacing = metrics.horizontalSpacing * (itemModel.sizeMode.widthMode.widthDivisor - 1)
-      let itemWidth = ((availableWidth - totalSpacing) / itemModel.sizeMode.widthMode.widthDivisor).rounded()
+      let itemWidth = ((availableWidthForItems - totalSpacing) / itemModel.sizeMode.widthMode.widthDivisor).rounded()
 
       let itemX = CGFloat(indexInCurrentRow) * itemWidth +
         CGFloat(indexInCurrentRow) * metrics.horizontalSpacing +
@@ -491,18 +491,25 @@ struct SectionModel {
 
     // Update the footer item
     if var newFooterModel = footerModel {
-      newFooterModel.originInSection = CGPoint(x: 0, y: currentY)
+      newFooterModel.originInSection = CGPoint(x: metrics.sectionInsets.left, y: currentY)
       newFooterModel.size.width = metrics.width
       newFooterModel.size.height = newFooterModel.preferredHeight ?? newFooterModel.size.height
       footerModel = newFooterModel
       currentHeight += newFooterModel.size.height
     }
 
-    // Update the background item
-    backgroundModel?.originInSection = .zero
-    backgroundModel?.size.width = metrics.width
-    backgroundModel?.size.height = currentHeight
-
+    // Finish our section height calculation
+    currentHeight += metrics.sectionInsets.bottom
     calculatedHeight = currentHeight
+
+    // Update the background item
+    backgroundModel?.originInSection = CGPoint(
+      x: metrics.sectionInsets.left,
+      y: metrics.sectionInsets.top)
+    backgroundModel?.size.width = metrics.width
+    backgroundModel?.size.height = currentHeight -
+      metrics.sectionInsets.top -
+      metrics.sectionInsets.bottom
   }
+
 }

--- a/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
+++ b/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
@@ -26,23 +26,13 @@ struct MagazineLayoutSectionMetrics: Equatable {
     layout: UICollectionViewLayout,
     delegate: UICollectionViewDelegateMagazineLayout)
   {
-    sectionInsets = delegate.collectionView(
-      collectionView,
-      layout: layout,
-      insetsForSectionAtIndex: sectionIndex)
+    collectionViewWidth = collectionView.bounds.width
 
-    let contentInsetAdjustedWidth: CGFloat
     if #available(iOS 11.0, *) {
-      contentInsetAdjustedWidth = collectionView.bounds.width -
-        collectionView.adjustedContentInset.left -
-        collectionView.adjustedContentInset.right
+      collectionViewContentInset = collectionView.adjustedContentInset
     } else {
-      contentInsetAdjustedWidth = collectionView.bounds.width -
-        collectionView.contentInset.left -
-        collectionView.contentInset.right
+      collectionViewContentInset = collectionView.contentInset
     }
-
-    width = contentInsetAdjustedWidth - sectionInsets.left - sectionInsets.right
 
     verticalSpacing = delegate.collectionView(
       collectionView,
@@ -54,6 +44,11 @@ struct MagazineLayoutSectionMetrics: Equatable {
       layout: layout,
       horizontalSpacingForItemsInSectionAtIndex: sectionIndex)
 
+    sectionInsets = delegate.collectionView(
+      collectionView,
+      layout: layout,
+      insetsForSectionAtIndex: sectionIndex)
+
     itemInsets = delegate.collectionView(
       collectionView,
       layout: layout,
@@ -61,13 +56,15 @@ struct MagazineLayoutSectionMetrics: Equatable {
   }
 
   private init(
-    width: CGFloat,
+    collectionViewWidth: CGFloat,
+    collectionViewContentInset: UIEdgeInsets,
     verticalSpacing: CGFloat,
     horizontalSpacing: CGFloat,
     sectionInsets: UIEdgeInsets,
     itemInsets: UIEdgeInsets)
   {
-    self.width = width
+    self.collectionViewWidth = collectionViewWidth
+    self.collectionViewContentInset = collectionViewContentInset
     self.verticalSpacing = verticalSpacing
     self.horizontalSpacing = horizontalSpacing
     self.sectionInsets = sectionInsets
@@ -76,7 +73,14 @@ struct MagazineLayoutSectionMetrics: Equatable {
 
   // MARK: Internal
 
-  var width: CGFloat
+  var width: CGFloat {
+    return collectionViewWidth -
+      collectionViewContentInset.left -
+      collectionViewContentInset.right -
+      sectionInsets.left -
+      sectionInsets.right
+  }
+
   var verticalSpacing: CGFloat
   var horizontalSpacing: CGFloat
   var sectionInsets: UIEdgeInsets
@@ -87,11 +91,17 @@ struct MagazineLayoutSectionMetrics: Equatable {
     -> MagazineLayoutSectionMetrics
   {
     return MagazineLayoutSectionMetrics(
-      width: width,
+      collectionViewWidth: width,
+      collectionViewContentInset: .zero,
       verticalSpacing: MagazineLayout.Default.VerticalSpacing,
       horizontalSpacing: MagazineLayout.Default.HorizontalSpacing,
       sectionInsets: MagazineLayout.Default.SectionInsets,
       itemInsets: MagazineLayout.Default.ItemInsets)
   }
+
+  // MARK: Private
+
+  private let collectionViewWidth: CGFloat
+  private let collectionViewContentInset: UIEdgeInsets
 
 }

--- a/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
+++ b/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
@@ -26,23 +26,34 @@ struct MagazineLayoutSectionMetrics: Equatable {
     layout: UICollectionViewLayout,
     delegate: UICollectionViewDelegateMagazineLayout)
   {
+    sectionInsets = delegate.collectionView(
+      collectionView,
+      layout: layout,
+      insetsForSectionAtIndex: sectionIndex)
+
+    let contentInsetAdjustedWidth: CGFloat
     if #available(iOS 11.0, *) {
-      width = collectionView.bounds.width -
+      contentInsetAdjustedWidth = collectionView.bounds.width -
         collectionView.adjustedContentInset.left -
         collectionView.adjustedContentInset.right
     } else {
-      width = collectionView.bounds.width -
+      contentInsetAdjustedWidth = collectionView.bounds.width -
         collectionView.contentInset.left -
         collectionView.contentInset.right
     }
+
+    width = contentInsetAdjustedWidth - sectionInsets.left - sectionInsets.right
+
     verticalSpacing = delegate.collectionView(
       collectionView,
       layout: layout,
       verticalSpacingForElementsInSectionAtIndex: sectionIndex)
+
     horizontalSpacing = delegate.collectionView(
       collectionView,
       layout: layout,
       horizontalSpacingForItemsInSectionAtIndex: sectionIndex)
+
     itemInsets = delegate.collectionView(
       collectionView,
       layout: layout,
@@ -53,11 +64,13 @@ struct MagazineLayoutSectionMetrics: Equatable {
     width: CGFloat,
     verticalSpacing: CGFloat,
     horizontalSpacing: CGFloat,
+    sectionInsets: UIEdgeInsets,
     itemInsets: UIEdgeInsets)
   {
     self.width = width
     self.verticalSpacing = verticalSpacing
     self.horizontalSpacing = horizontalSpacing
+    self.sectionInsets = sectionInsets
     self.itemInsets = itemInsets
   }
 
@@ -66,6 +79,7 @@ struct MagazineLayoutSectionMetrics: Equatable {
   var width: CGFloat
   var verticalSpacing: CGFloat
   var horizontalSpacing: CGFloat
+  var sectionInsets: UIEdgeInsets
   var itemInsets: UIEdgeInsets
 
   static func defaultSectionMetrics(
@@ -76,6 +90,7 @@ struct MagazineLayoutSectionMetrics: Equatable {
       width: width,
       verticalSpacing: MagazineLayout.Default.VerticalSpacing,
       horizontalSpacing: MagazineLayout.Default.HorizontalSpacing,
+      sectionInsets: MagazineLayout.Default.SectionInsets,
       itemInsets: MagazineLayout.Default.ItemInsets)
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -53,10 +53,10 @@ public final class MagazineLayout: UICollectionViewLayout {
       // This is a workaround for `layoutAttributesForElementsInRect:` not getting invoked enough
       // times if `collectionViewContentSize.width` is not smaller than the width of the collection
       // view, minus horizontal insets. This results in visual defects when performing batch
-      // updates. To work around this, we subtract 0.0001 from our content size width calculation -
+      // updates. To work around this, we subtract 0.0001 from our content size width calculation;
       // this small decrease in `collectionViewContentSize.width` is enough to work around the
       // incorrect, internal collection view `CGRect` checks, without introducing any visual
-      // difference for elements in the collection view.
+      // differences for elements in the collection view.
       // See https://openradar.appspot.com/radar?id=5025850143539200 for more details.
       width = collectionView.bounds.width - contentInset.left - contentInset.right - 0.0001
     } else {

--- a/MagazineLayout/Public/Types/MagazineLayout+Default.swift
+++ b/MagazineLayout/Public/Types/MagazineLayout+Default.swift
@@ -32,6 +32,7 @@ extension MagazineLayout {
     public static let FooterHeight: CGFloat = 44
     public static let VerticalSpacing: CGFloat = 0
     public static let HorizontalSpacing: CGFloat = 0
+    public static let SectionInsets: UIEdgeInsets = .zero
     public static let ItemInsets: UIEdgeInsets = .zero
 
   }

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -45,13 +45,12 @@ public struct MagazineLayoutItemSizeMode {
 /// room.
 public enum MagazineLayoutItemWidthMode {
 
-  /// Full width items will fill the entire width of the collection view.
+  /// Full width items will fill the available width in a section.
   ///
   /// Use this width mode to create lists of items.
-  /// `respectsHorizontalInsets` specifies whether the item should be edge-to-edge in the collection
-  /// view, or if it should be inset by `contentInset.left` and `contentInset.right`. On iOS 11 and
-  /// higher, this will also take the safe area insets into account by insetting the item by
-  /// `adjustedContentInset.left` and `adjustedContentInset.right`.
+  /// `respectsHorizontalInsets` specifies whether the item should be edge-to-edge in a section, or
+  /// if it should be inset by the item insets specified for a section. `respectsHorizontalInsets`
+  /// does not take into account section insets or the collection view's content inset.
   case fullWidth(respectsHorizontalInsets: Bool)
 
   /// Fractional width items will take up `1/divisor` of the available width for a given row of

--- a/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
+++ b/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
@@ -17,28 +17,28 @@ import UIKit
 
 public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate {
 
-///   Asks the delegate for the size mode of the specified item.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - indexPath: The index path of the item.
-///
-///   - Returns: The size mode of the specified item.
+  ///   Asks the delegate for the size mode of the specified item.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - indexPath: The index path of the item.
+  ///
+  ///   - Returns: The size mode of the specified item.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     sizeModeForItemAt indexPath: IndexPath)
     -> MagazineLayoutItemSizeMode
 
-///   Asks the delegate for the visibility mode of the header in the specified section.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - index: The index of the section containing the header.
-///
-///   - Returns: The visibility mode of the header in the specified section.
+  ///   Asks the delegate for the visibility mode of the header in the specified section.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the header.
+  ///
+  ///   - Returns: The visibility mode of the header in the specified section.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
@@ -59,56 +59,76 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     visibilityModeForFooterInSectionAtIndex index: Int)
     -> MagazineLayoutFooterVisibilityMode
 
-///   Asks the delegate for the visibility mode of the background in the specified section.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - index: The index of the section containing the background.
-///
-///   - Returns: The visibility mode of the background in the specified section.
+  ///   Asks the delegate for the visibility mode of the background in the specified section.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the background.
+  ///
+  ///   - Returns: The visibility mode of the background in the specified section.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     visibilityModeForBackgroundInSectionAtIndex index: Int)
     -> MagazineLayoutBackgroundVisibilityMode
 
-///   Asks the delegate for the horizontal spacing for items in the specified section.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - index: The index of the section whose horizontal item spacing is needed.
-///
-///   - Returns: The horizontal spacing for items in the specified section.
+  ///   Asks the delegate for the horizontal spacing for items in the specified section.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section whose horizontal item spacing is needed.
+  ///
+  ///   - Returns: The horizontal spacing for items in the specified section.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     horizontalSpacingForItemsInSectionAtIndex index: Int)
     -> CGFloat
 
-///   Asks the delegate for the vertical spacing for items in the specified section.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - index: The index of the section whose vertical item spacing is needed.
-///
-///   - Returns: The vertical spacing for items in the specified section.
+  ///   Asks the delegate for the vertical spacing for items in the specified section.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section whose vertical item spacing is needed.
+  ///
+  ///   - Returns: The vertical spacing for items in the specified section.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     verticalSpacingForElementsInSectionAtIndex index: Int)
     -> CGFloat
 
-///   Asks the delegate for the amount by which to inset items in the specified section.
-///
-///   - Parameters:
-///      - collectionView: The collection view using the layout.
-///      - collectionViewLayout: The layout requesting the information.
-///      - index: The index of the section whose item insets are needed.
-///
-///   - Returns: The amount by which to inset items in the specified section.
+  ///   Asks the delegate for the amount by which to inset elements in the specified section.
+  ///
+  ///   Section insets are relative to the content's bounds, which is impacted by the collection
+  ///   view's content inset.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section whose element insets are needed.
+  ///
+  ///   - Returns: The amount by which to inset elements in the specified section.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    insetsForSectionAtIndex index: Int)
+    -> UIEdgeInsets
+
+  ///   Asks the delegate for the amount by which to inset items in the specified section.
+  ///
+  ///   Item insets are relative to the section's bounds, which is impacted by the section's insets
+  ///   and, transitively, the collection view's content inset.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section whose item insets are needed.
+  ///
+  ///   - Returns: The amount by which to inset items in the specified section.
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A collection view layout capable of laying out views in vertically scrolling gri
 Other features:
 - Specifying horizontal item spacing on a per-section basis
 - Specifying vertical row spacing on a per-section basis
+- Specifying section insets on a per-section basis
 - Specifying item insets on a per-section basis
 
 These capabilities have allowed us to build a wide variety of screens in the Airbnb app, many of which are among our highest-traffic screens. Here are just a few examples of screens laid out using `MagazineLayout`:
@@ -217,6 +218,10 @@ extension  ViewController: UICollectionViewDelegateMagazineLayout {
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, verticalSpacingForElementsInSectionAtIndex index: Int) -> CGFloat {
     return  12
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetsForSectionAtIndex index: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 8, bottom: 24, right: 8)
   }
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetsForItemsInSectionAtIndex index: Int) -> UIEdgeInsets {

--- a/Tests/ModelStateEmptySectionLayoutTests.swift
+++ b/Tests/ModelStateEmptySectionLayoutTests.swift
@@ -31,9 +31,11 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
 
   func testEmptySectionsLayout() {
     var metrics0 = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 320)
+    metrics0.sectionInsets = .zero
     metrics0.itemInsets = UIEdgeInsets(top: 10, left: 0, bottom: 20, right: 0)
 
     var metrics1 = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 320)
+    metrics1.sectionInsets = UIEdgeInsets(top: -25, left: 0, bottom: 20, right: 10)
     metrics1.itemInsets = UIEdgeInsets(top: 50, left: 0, bottom: 100, right: 0)
 
     let initialSections = [
@@ -54,15 +56,17 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
 
     XCTAssert(
       (modelState.sectionMaxY(forSectionAtIndex: 0, .afterUpdates) == 30 &&
-        modelState.sectionMaxY(forSectionAtIndex: 1, .afterUpdates) == 150 + 30),
+       modelState.sectionMaxY(forSectionAtIndex: 1, .afterUpdates) == 30 + 145),
       "The layout has incorrect heights for its sections")
   }
 
   func testEmptySectionsWithHeadersFootersAndBackgroundsLayout() {
     var metrics0 = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 320)
+    metrics0.sectionInsets = UIEdgeInsets(top: 10, left: 5, bottom: 20, right: 5)
     metrics0.itemInsets = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 10)
 
     var metrics1 = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 320)
+    metrics1.sectionInsets = .zero
     metrics1.itemInsets = UIEdgeInsets(top: 50, left: 10, bottom: 100, right: 10)
 
     let initialSections = [
@@ -82,8 +86,8 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
     modelState.setSections(initialSections)
 
     let expectedHeaderFrames = [
-      CGRect(x: 0, y: 0, width: 320, height: 45),
-      CGRect(x: 0, y: 120, width: 320, height: 65),
+      CGRect(x: 5, y: 10, width: 310, height: 45),
+      CGRect(x: 0, y: 150, width: 320, height: 65),
     ]
     XCTAssert(
       FrameHelpers.expectedFrames(
@@ -92,20 +96,9 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
         modelState: modelState),
       "Header frames are incorrect")
 
-    let expectedBackgroundFrames = [
-      CGRect(x: 0, y: 0, width: 320, height: 120),
-      CGRect(x: 0, y: 120, width: 320, height: 280),
-    ]
-    XCTAssert(
-      FrameHelpers.expectedFrames(
-        expectedBackgroundFrames,
-        matchBackgroundFramesInSectionIndexRange: 0..<modelState.numberOfSections(.afterUpdates),
-        modelState: modelState),
-      "Header frames are incorrect")
-
     let expectedFooterFrames = [
-      CGRect(x: 0, y: 75, width: 320, height: 45),
-      CGRect(x: 0, y: 335, width: 320, height: 65)
+      CGRect(x: 5, y: 85, width: 310, height: 45),
+      CGRect(x: 0, y: 365, width: 320, height: 65)
     ]
     XCTAssert(
       FrameHelpers.expectedFrames(
@@ -114,6 +107,17 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
         0..<modelState.numberOfSections(.afterUpdates),
         modelState: modelState),
       "Footer frames are incorrect")
+
+    let expectedBackgroundFrames = [
+      CGRect(x: 5, y: 10, width: 310, height: 120),
+      CGRect(x: 0, y: 150, width: 320, height: 280),
+    ]
+    XCTAssert(
+      FrameHelpers.expectedFrames(
+        expectedBackgroundFrames,
+        matchBackgroundFramesInSectionIndexRange: 0..<modelState.numberOfSections(.afterUpdates),
+        modelState: modelState),
+      "Background frames are incorrect")
   }
 
   // MARK: Private

--- a/Tests/ModelStateLayoutTests.swift
+++ b/Tests/ModelStateLayoutTests.swift
@@ -23,6 +23,7 @@ final class ModelStateLayoutTests: XCTestCase {
 
   override func setUp() {
     var metrics = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 320)
+    metrics.sectionInsets = UIEdgeInsets(top: 30, left: 15, bottom: 20, right: 5)
     metrics.itemInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
     metrics.horizontalSpacing = 20
     metrics.verticalSpacing = 30
@@ -56,50 +57,52 @@ final class ModelStateLayoutTests: XCTestCase {
 
   func testInitialLayout() {
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1180.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1180.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1240.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1295.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1340.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1390.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1430.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1430.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1430.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1495.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1260.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1260.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1320.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1375.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1420.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1470.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1510.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1510.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1575.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
-    ]
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
+      ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames0 = [CGRect]()
+    let expectedFooterFrames0: [CGRect] = [
+    ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1520.0, width: 320.0, height: 70.0)
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1600.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
     ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -134,53 +137,51 @@ final class ModelStateLayoutTests: XCTestCase {
 
     modelState.updateFooterHeight(toPreferredHeight: 50, forSectionAtIndex: 1)
 
-    let expectedItemFrames0 = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 15.0),
-      CGRect(x: 10.0, y: 155.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 155.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 215.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 270.0, width: 87.0, height: 15.0),
-      CGRect(x: 117.0, y: 270.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 315.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 315.0, width: 60.0, height: 15.0),
-      CGRect(x: 170.0, y: 315.0, width: 60.0, height: 25.0),
-      CGRect(x: 250.0, y: 315.0, width: 60.0, height: 35.0),
-      CGRect(x: 10.0, y: 380.0, width: 44.0, height: 30.0),
+    let expectedItemFrames0: [CGRect] = [
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 15.0),
+      CGRect(x: 25.0, y: 185.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 185.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 245.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 300.0, width: 80.0, height: 15.0),
+      CGRect(x: 125.0, y: 300.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 345.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 345.0, width: 55.0, height: 15.0),
+      CGRect(x: 175.0, y: 345.0, width: 55.0, height: 25.0),
+      CGRect(x: 250.0, y: 345.0, width: 55.0, height: 35.0),
+      CGRect(x: 25.0, y: 410.0, width: 40.0, height: 30.0),
     ]
-    let expectedItemFrames1 = [
-      CGRect(x: 10.0, y: 530.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 530.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 590.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 645.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 690.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 740.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 780.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 780.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 780.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 780.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 780.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 845.0, width: 320.0, height: 15.0),
+    let expectedItemFrames1: [CGRect] = [
+      CGRect(x: 25.0, y: 610.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 610.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 670.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 725.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 770.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 820.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 860.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 860.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 860.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 860.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 860.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 925.0, width: 300.0, height: 15.0),
     ]
-    let expectedHeaderFrames0 = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 470.0, width: 320.0, height: 50.0),
+    let expectedHeaderFrames0: [CGRect] = [
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 470.0, width: 320.0, height: 50.0)
+      CGRect(x: 15.0, y: 550.0, width: 300.0, height: 50.0),
     ]
     let expectedFooterFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 420.0, width: 320.0, height: 50.0)
+      CGRect(x: 15.0, y: 450.0, width: 300.0, height: 50.0),
     ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 870.0, width: 320.0, height: 50.0)
+      CGRect(x: 15.0, y: 950.0, width: 300.0, height: 50.0),
     ]
-    let expectedBackgroundFrames0 = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 470.0),
-      CGRect(x: 0.0, y: 470.0, width: 320.0, height: 450.0),
+    let expectedBackgroundFrames0: [CGRect] = [
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 470.0),
     ]
-    let expectedBackgroundFrames1 = [
-      CGRect(x: 0.0, y: 470.0, width: 320.0, height: 450.0),
+    let expectedBackgroundFrames1: [CGRect] = [
+      CGRect(x: 15.0, y: 550.0, width: 300.0, height: 450.0),
     ]
 
     checkExpectedFrames(
@@ -196,56 +197,58 @@ final class ModelStateLayoutTests: XCTestCase {
 
   func testUpdatingSectionMetrics() {
     var metrics = MagazineLayoutSectionMetrics.defaultSectionMetrics(forCollectionViewWidth: 100)
+    metrics.sectionInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
     metrics.itemInsets = UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2)
     metrics.horizontalSpacing = 5
     metrics.verticalSpacing = 100
     modelState.updateMetrics(to: metrics, forSectionAtIndex: 0)
 
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 2.0, y: 52.0, width: 96.0, height: 20.0),
-      CGRect(x: 0.0, y: 172.0, width: 100.0, height: 150.0),
-      CGRect(x: 2.0, y: 422.0, width: 46.0, height: 10.0),
-      CGRect(x: 53.0, y: 422.0, width: 46.0, height: 30.0),
+      CGRect(x: 6.0, y: 56.0, width: 88.0, height: 20.0),
+      CGRect(x: 4.0, y: 176.0, width: 92.0, height: 150.0),
+      CGRect(x: 6.0, y: 426.0, width: 42.0, height: 10.0),
+      CGRect(x: 53.0, y: 426.0, width: 42.0, height: 30.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 2.0, y: 552.0, width: 46.0, height: 150.0),
-      CGRect(x: 2.0, y: 802.0, width: 29.0, height: 150.0),
-      CGRect(x: 36.0, y: 802.0, width: 29.0, height: 150.0),
-      CGRect(x: 2.0, y: 1052.0, width: 20.0, height: 15.0),
-      CGRect(x: 27.0, y: 1052.0, width: 20.0, height: 150.0),
-      CGRect(x: 52.0, y: 1052.0, width: 20.0, height: 150.0),
-      CGRect(x: 77.0, y: 1052.0, width: 20.0, height: 150.0),
-      CGRect(x: 2.0, y: 1302.0, width: 15.0, height: 150.0),
-      CGRect(x: 10.0, y: 1584.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1584.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1644.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1699.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1744.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1794.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1834.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1834.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1834.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1834.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1834.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1899.0, width: 320.0, height: 15.0),
+      CGRect(x: 6.0, y: 556.0, width: 42.0, height: 150.0),
+      CGRect(x: 6.0, y: 806.0, width: 26.0, height: 150.0),
+      CGRect(x: 37.0, y: 806.0, width: 26.0, height: 150.0),
+      CGRect(x: 6.0, y: 1056.0, width: 18.0, height: 15.0),
+      CGRect(x: 29.0, y: 1056.0, width: 18.0, height: 150.0),
+      CGRect(x: 52.0, y: 1056.0, width: 18.0, height: 150.0),
+      CGRect(x: 75.0, y: 1056.0, width: 18.0, height: 150.0),
+      CGRect(x: 6.0, y: 1306.0, width: 14.0, height: 150.0),
+      CGRect(x: 25.0, y: 1622.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1622.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1682.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1737.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1782.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1832.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1872.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1872.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1872.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1872.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1872.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1937.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 100.0, height: 50.0),
+      CGRect(x: 4.0, y: 4.0, width: 92.0, height: 50.0),
     ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1504.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1542.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames0 = [CGRect]()
+    let expectedFooterFrames0: [CGRect] = [
+    ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1454.0, width: 100.0, height: 50.0),
-      CGRect(x: 0.0, y: 1924.0, width: 320.0, height: 70.0)
+      CGRect(x: 4.0, y: 1458.0, width: 92.0, height: 50.0),
+      CGRect(x: 15.0, y: 1962.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 100.0, height: 1504.0),
+      CGRect(x: 4.0, y: 4.0, width: 92.0, height: 1504.0),
     ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 100.0, height: 1504.0),
-      CGRect(x: 0.0, y: 1504.0, width: 320.0, height: 490.0),
+      CGRect(x: 4.0, y: 4.0, width: 92.0, height: 1504.0),
+      CGRect(x: 15.0, y: 1542.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -272,50 +275,52 @@ final class ModelStateLayoutTests: XCTestCase {
       forItemAt: IndexPath(item: 8, section: 1))
 
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 50.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1180.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1180.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1240.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1295.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1340.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1390.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1430.0, width: 44.0, height: 35.0),
-      CGRect(x: 202.0, y: 1430.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1430.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1495.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 50.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1260.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1260.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1320.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1375.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1420.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1470.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 205.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1510.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1575.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames0 = [CGRect]()
+    let expectedFooterFrames0: [CGRect] = [
+    ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1520.0, width: 320.0, height: 70.0)
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1600.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
     ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -333,50 +338,50 @@ final class ModelStateLayoutTests: XCTestCase {
     modelState.removeHeader(forSectionAtIndex: 0)
 
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 10.0, y: 10.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 60.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 240.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 240.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 300.0, width: 140.0, height: 150.0),
-      CGRect(x: 10.0, y: 480.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 480.0, width: 87.0, height: 150.0),
+      CGRect(x: 25.0, y: 40.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 90.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 270.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 270.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 330.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 10.0, y: 480.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 480.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 660.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 660.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 660.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 660.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 840.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1130.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1130.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1190.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1245.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1290.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1340.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1380.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1380.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1380.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1380.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1380.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1445.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 510.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 510.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 690.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 690.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 690.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 690.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 870.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1210.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1210.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1270.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1325.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1370.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1420.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1460.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1460.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1460.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1460.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1460.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1525.0, width: 300.0, height: 15.0),
     ]
-    let expectedHeaderFrames0: [CGRect] = []
+    let expectedHeaderFrames0: [CGRect] = [
+    ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1130.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames0 = [CGRect]()
+    let expectedFooterFrames0: [CGRect] = [
+    ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1000.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1470.0, width: 320.0, height: 70.0)
+      CGRect(x: 15.0, y: 1030.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1550.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1050.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1050.0),
     ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1050.0),
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1050.0),
+      CGRect(x: 15.0, y: 1130.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -397,51 +402,52 @@ final class ModelStateLayoutTests: XCTestCase {
       forSectionAtIndex: 1)
 
     let expectedItemFrames2: [CGRect] = [
-      CGRect(x: 10.0, y: 70.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 120.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 300.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 300.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 360.0, width: 140.0, height: 150.0),
-      ]
+      CGRect(x: 25.0, y: 100.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 150.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 330.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 330.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 390.0, width: 130.0, height: 150.0),
+    ]
     let expectedItemFrames3: [CGRect] = [
-      CGRect(x: 10.0, y: 360.0, width: 140.0, height: 150.0),
-      CGRect(x: 10.0, y: 540.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 540.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 720.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 720.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 720.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 720.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 900.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1220.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1220.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1280.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1335.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1380.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1430.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1470.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1470.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1470.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1470.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1470.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1535.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 390.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 570.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 570.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 750.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 750.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 750.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 750.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 930.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1300.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1300.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1360.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1415.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1460.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1510.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1550.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1550.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1550.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1550.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1550.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1615.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 60.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 60.0),
     ]
     let expectedHeaderFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1110.0, width: 320.0, height: 100.0),
+      CGRect(x: 15.0, y: 1190.0, width: 300.0, height: 100.0),
     ]
-    let expectedFooterFrames2 = [CGRect]()
+    let expectedFooterFrames2: [CGRect] = [
+    ]
     let expectedFooterFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1060.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1560.0, width: 320.0, height: 70.0)
+      CGRect(x: 15.0, y: 1090.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1640.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1110.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1110.0),
     ]
     let expectedBackgroundFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1110.0),
-      CGRect(x: 0.0, y: 1110.0, width: 320.0, height: 520.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1110.0),
+      CGRect(x: 15.0, y: 1190.0, width: 300.0, height: 520.0),
     ]
 
     checkExpectedFrames(
@@ -459,50 +465,51 @@ final class ModelStateLayoutTests: XCTestCase {
     modelState.removeFooter(forSectionAtIndex: 0)
 
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1130.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1130.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1190.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1245.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1290.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1340.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1380.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1380.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1380.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1380.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1380.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1445.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1210.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1210.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1270.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1325.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1370.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1420.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1460.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1460.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1460.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1460.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1460.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1525.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1130.0, width: 300.0, height: 70.0),
     ]
     let expectedFooterFrames0: [CGRect] = [
     ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1470.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1550.0, width: 300.0, height: 70.0),
     ]
     let expectedBackgroundFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1050.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1050.0),
     ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1050.0),
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1050.0),
+      CGRect(x: 15.0, y: 1130.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -524,51 +531,52 @@ final class ModelStateLayoutTests: XCTestCase {
       forSectionAtIndex: 1)
 
     let expectedItemFrames2: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames3: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1170.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1170.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1230.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1285.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1330.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1380.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1420.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1420.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1420.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1420.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1420.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1485.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1250.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1250.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1310.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1365.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1410.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1460.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1500.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1500.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1500.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1500.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1500.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1565.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1090.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1170.0, width: 300.0, height: 70.0),
     ]
     let expectedFooterFrames2: [CGRect] = [
     ]
     let expectedFooterFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 40.0),
-      CGRect(x: 0.0, y: 1510.0, width: 320.0, height: 120.0),
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 40.0),
+      CGRect(x: 15.0, y: 1590.0, width: 300.0, height: 120.0),
     ]
     let expectedBackgroundFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1090.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1090.0),
     ]
     let expectedBackgroundFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1090.0),
-      CGRect(x: 0.0, y: 1090.0, width: 320.0, height: 540.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1090.0),
+      CGRect(x: 15.0, y: 1170.0, width: 300.0, height: 540.0),
     ]
 
     checkExpectedFrames(
@@ -586,47 +594,50 @@ final class ModelStateLayoutTests: XCTestCase {
     modelState.removeBackground(forSectionAtIndex: 0)
 
     let expectedItemFrames0: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames1: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1180.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1180.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1240.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1295.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1340.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1390.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1430.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1430.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1430.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1495.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1260.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1260.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1320.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1375.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1420.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1470.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1510.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1510.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1575.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames0: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames0 = [CGRect]()
+    let expectedFooterFrames0: [CGRect] = [
+    ]
     let expectedFooterFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1520.0, width: 320.0, height: 70.0),
-      ]
-    let expectedBackgroundFrames0: [CGRect] = []
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1600.0, width: 300.0, height: 70.0),
+    ]
+    let expectedBackgroundFrames0: [CGRect] = [
+    ]
     let expectedBackgroundFrames1: [CGRect] = [
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(
@@ -642,50 +653,52 @@ final class ModelStateLayoutTests: XCTestCase {
     modelState.setBackground(BackgroundModel(), forSectionAtIndex: 0)
 
     let expectedItemFrames2: [CGRect] = [
-      CGRect(x: 10.0, y: 60.0, width: 300.0, height: 20.0),
-      CGRect(x: 0.0, y: 110.0, width: 320.0, height: 150.0),
-      CGRect(x: 10.0, y: 290.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 290.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 350.0, width: 140.0, height: 150.0),
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
     ]
     let expectedItemFrames3: [CGRect] = [
-      CGRect(x: 10.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 117.0, y: 530.0, width: 87.0, height: 150.0),
-      CGRect(x: 10.0, y: 710.0, width: 60.0, height: 15.0),
-      CGRect(x: 90.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 170.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 250.0, y: 710.0, width: 60.0, height: 150.0),
-      CGRect(x: 10.0, y: 890.0, width: 44.0, height: 150.0),
-      CGRect(x: 10.0, y: 1180.0, width: 140.0, height: 10.0),
-      CGRect(x: 170.0, y: 1180.0, width: 140.0, height: 30.0),
-      CGRect(x: 10.0, y: 1240.0, width: 140.0, height: 25.0),
-      CGRect(x: 10.0, y: 1295.0, width: 87.0, height: 15.0),
-      CGRect(x: 10.0, y: 1340.0, width: 300.0, height: 20.0),
-      CGRect(x: 10.0, y: 1390.0, width: 87.0, height: 10.0),
-      CGRect(x: 10.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 74.0, y: 1430.0, width: 44.0, height: 15.0),
-      CGRect(x: 138.0, y: 1430.0, width: 44.0, height: 25.0),
-      CGRect(x: 202.0, y: 1430.0, width: 44.0, height: 35.0),
-      CGRect(x: 266.0, y: 1430.0, width: 44.0, height: 30.0),
-      CGRect(x: 0.0, y: 1495.0, width: 320.0, height: 15.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1260.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1260.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1320.0, width: 130.0, height: 25.0),
+      CGRect(x: 25.0, y: 1375.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1420.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1470.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1510.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1510.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1575.0, width: 300.0, height: 15.0),
     ]
     let expectedHeaderFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 50.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
     ]
     let expectedHeaderFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 70.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 70.0),
     ]
-    let expectedFooterFrames2 = [CGRect]()
+    let expectedFooterFrames2: [CGRect] = [
+    ]
     let expectedFooterFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 1050.0, width: 320.0, height: 50.0),
-      CGRect(x: 0.0, y: 1520.0, width: 320.0, height: 70.0),
-      ]
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1600.0, width: 300.0, height: 70.0),
+    ]
     let expectedBackgroundFrames2: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
     ]
     let expectedBackgroundFrames3: [CGRect] = [
-      CGRect(x: 0.0, y: 0.0, width: 320.0, height: 1100.0),
-      CGRect(x: 0.0, y: 1100.0, width: 320.0, height: 490.0),
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 490.0),
     ]
 
     checkExpectedFrames(


### PR DESCRIPTION
## Details

Adds support for section insets. Section insets affect all elements (cells and supplementary views) in a section. Section insets are per-section, and are in addition to any content insets set on the collection view.
There is still a separate concept of item insets, which lets you inset items (cells) even further, which is useful for providing a gap between headers and the first row of items, and footers and the last row of items.

## Related Issue

https://github.com/airbnb/MagazineLayout/issues/24

## Motivation and Context

It's a common use case to want to have spacing between 2 sections. Section insets provide the most straightforward way to implement this spacing. Without section insets, we need to rely on workarounds like https://github.com/airbnb/MagazineLayout/issues/24#issuecomment-463972546 to create equivalent behavior (but even this won't work if you have section footers).

## How Has This Been Tested

Added new test cases and confirmed updated values make sense. Also tested in the sample project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.