### PR TITLE
Make RTL support configurable

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.0'
+  s.version  = '1.4.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -24,9 +24,25 @@ import UIKit
 /// change how many items are displayed in a row and how each item sizes vertically.
 public final class MagazineLayout: UICollectionViewLayout {
 
+  // MARK: Lifecycle
+
+  /// - Parameters:
+  ///   - flipsHorizontallyInOppositeLayoutDirection: Indicates whether the horizontal coordinate
+  ///     system is automatically flipped at appropriate times. In practice, this is used to support
+  ///     right-to-left layout.
+  public init(flipsHorizontallyInOppositeLayoutDirection: Bool = true) {
+    _flipsHorizontallyInOppositeLayoutDirection = flipsHorizontallyInOppositeLayoutDirection
+    super.init()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    _flipsHorizontallyInOppositeLayoutDirection = true
+    super.init(coder: aDecoder)
+  }
+
   // MARK: Public
 
-  override public class  var layoutAttributesClass: AnyClass {
+  override public class var layoutAttributesClass: AnyClass {
     return MagazineLayoutCollectionViewLayoutAttributes.self
   }
 
@@ -35,7 +51,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   override public var flipsHorizontallyInOppositeLayoutDirection: Bool {
-    return true
+    return _flipsHorizontallyInOppositeLayoutDirection
   }
 
   override public var collectionViewContentSize: CGSize {
@@ -701,6 +717,8 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   private let modelState = ModelState()
+  private let _flipsHorizontallyInOppositeLayoutDirection: Bool
+  
   private var cachedCollectionViewWidth: CGFloat?
 
   // These properties are used to prevent scroll jumpiness due to self-sizing after rotation; see


### PR DESCRIPTION
## Details

https://github.com/airbnb/MagazineLayout/pull/30 added RTL layout support, but did not make it configurable. To enable more control, I've added an initializer to control `flipsHorizontallyInOppositeLayoutDirection`, with a default of `true`.

## Related Issue

N/A

## Motivation and Context

This makes RTL support opt-out. Currently, it's not configurable at all.

## How Has This Been Tested

Tested RTL support in the sample app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.