### PR TITLE
When removing row data that index is more bigger than zero, `heightOfTallestItemInCurrentRow` is always zero.

### DIFF
--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -384,6 +384,13 @@ struct SectionModel {
       }
 
       indexInCurrentRow = consecutiveSameItemWidthModes % Int(startingItemWidthMode.widthDivisor) - 1
+
+      if indexInCurrentRow >= 0 {
+        for row in 0...indexInCurrentRow {
+          heightOfTallestItemInCurrentRow = max(heightOfTallestItemInCurrentRow, itemModels[startingIndex - row - 1].size.height)
+        }
+      }
+
       if indexInCurrentRow + 1 > 0 {
         // This is an item added to an existing row, so our `currentY` is just the preceding item's
         // `minY`.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ I'd also like to thank the following people, who have all helped pave the way fo
 - Yong Li
 - Luke Hiesterman
 - Jordan Harband
+- Chansim Youk
 
 ## License
 


### PR DESCRIPTION
## Details

When removing row data that index is more bigger than zero, `heightOfTallestItemInCurrentRow` is always zero. So if there exist row that is more taller height than removed index, layout cause error.

## Related Issue

#40

## Motivation and Context

If this pull request is merged in master, a bug will be fixed.

## How Has This Been Tested

Tested using the example project and unit tests.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.