### PR TITLE
Fix item layout bug (#40)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.1'
+  s.version  = '1.4.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -377,17 +377,27 @@ struct SectionModel {
       let startingItemWidthMode = itemModels[startingIndex].sizeMode.widthMode
       previousWidthMode = itemModels[startingIndex - 1].sizeMode.widthMode
 
-      var consecutiveSameItemWidthModes = 0
+      let previousItemMinY = frameForItem(atIndex: startingIndex - 1).minY
+      var consecutiveSameItemWidthModesInRow = 0
       for itemModel in itemModelsBeforeStartingIndex {
-        guard itemModel.sizeMode.widthMode == startingItemWidthMode else { break }
-        consecutiveSameItemWidthModes += 1
+        guard
+          itemModel.sizeMode.widthMode == startingItemWidthMode,
+          itemModel.originInSection.y == previousItemMinY else
+        {
+          break
+        }
+
+        consecutiveSameItemWidthModesInRow += 1
+        heightOfTallestItemInCurrentRow = max(
+          heightOfTallestItemInCurrentRow,
+          itemModel.size.height)
       }
 
-      indexInCurrentRow = consecutiveSameItemWidthModes % Int(startingItemWidthMode.widthDivisor) - 1
+      indexInCurrentRow = consecutiveSameItemWidthModesInRow % Int(startingItemWidthMode.widthDivisor) - 1
       if indexInCurrentRow + 1 > 0 {
         // This is an item added to an existing row, so our `currentY` is just the preceding item's
         // `minY`.
-        currentY = frameForItem(atIndex: startingIndex - 1).minY
+        currentY = previousItemMinY
       }
       else {
         // This is the start of a new row, so our `currentY` is the `maxY` of the items in the

--- a/Tests/ModelStateLayoutTests.swift
+++ b/Tests/ModelStateLayoutTests.swift
@@ -334,6 +334,79 @@ final class ModelStateLayoutTests: XCTestCase {
       expectedBackgroundFrames1: expectedBackgroundFrames1)
   }
 
+  func testLayoutAfterInsertingItem() {
+    // Tests the scenario that reproduces https://github.com/airbnb/MagazineLayout/issues/40
+    modelState.applyUpdates([
+      .itemInsert(
+        itemIndexPath: IndexPath(item: 3, section: 1),
+        newItem: ItemModel(
+          sizeMode: MagazineLayoutItemSizeMode(
+            widthMode: .halfWidth,
+            heightMode: .static(height: 10)),
+          height: 10))
+      ])
+
+    let expectedItemFrames0: [CGRect] = [
+      CGRect(x: 25.0, y: 90.0, width: 280.0, height: 20.0),
+      CGRect(x: 15.0, y: 140.0, width: 300.0, height: 150.0),
+      CGRect(x: 25.0, y: 320.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 320.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+    ]
+    let expectedItemFrames1: [CGRect] = [
+      CGRect(x: 25.0, y: 380.0, width: 130.0, height: 150.0),
+      CGRect(x: 25.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 125.0, y: 560.0, width: 80.0, height: 150.0),
+      CGRect(x: 25.0, y: 740.0, width: 55.0, height: 15.0),
+      CGRect(x: 100.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 175.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 250.0, y: 740.0, width: 55.0, height: 150.0),
+      CGRect(x: 25.0, y: 920.0, width: 40.0, height: 150.0),
+      CGRect(x: 25.0, y: 1260.0, width: 130.0, height: 10.0),
+      CGRect(x: 175.0, y: 1260.0, width: 130.0, height: 30.0),
+      CGRect(x: 25.0, y: 1320.0, width: 130.0, height: 25.0),
+      CGRect(x: 175.0, y: 1320.0, width: 130.0, height: 10.0),
+      CGRect(x: 25.0, y: 1375.0, width: 80.0, height: 15.0),
+      CGRect(x: 25.0, y: 1420.0, width: 280.0, height: 20.0),
+      CGRect(x: 25.0, y: 1470.0, width: 80.0, height: 10.0),
+      CGRect(x: 25.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 85.0, y: 1510.0, width: 40.0, height: 15.0),
+      CGRect(x: 145.0, y: 1510.0, width: 40.0, height: 25.0),
+      CGRect(x: 205.0, y: 1510.0, width: 40.0, height: 35.0),
+      CGRect(x: 265.0, y: 1510.0, width: 40.0, height: 30.0),
+      CGRect(x: 15.0, y: 1575.0, width: 300.0, height: 15.0),
+    ]
+    let expectedHeaderFrames0: [CGRect] = [
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 50.0),
+    ]
+    let expectedHeaderFrames1: [CGRect] = [
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 70.0),
+    ]
+    let expectedFooterFrames0: [CGRect] = [
+    ]
+    let expectedFooterFrames1: [CGRect] = [
+      CGRect(x: 15.0, y: 1080.0, width: 300.0, height: 50.0),
+      CGRect(x: 15.0, y: 1600.0, width: 300.0, height: 70.0),
+    ]
+    let expectedBackgroundFrames0: [CGRect] = [
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
+    ]
+    let expectedBackgroundFrames1: [CGRect] = [
+      CGRect(x: 15.0, y: 30.0, width: 300.0, height: 1100.0),
+      CGRect(x: 15.0, y: 1180.0, width: 300.0, height: 490.0),
+    ]
+
+    checkExpectedFrames(
+      expectedItemFrames0: expectedItemFrames0,
+      expectedItemFrames1: expectedItemFrames1,
+      expectedHeaderFrames0: expectedHeaderFrames0,
+      expectedHeaderFrames1: expectedHeaderFrames1,
+      expectedFooterFrames0: expectedFooterFrames0,
+      expectedFooterFrames1: expectedFooterFrames1,
+      expectedBackgroundFrames0: expectedBackgroundFrames0,
+      expectedBackgroundFrames1: expectedBackgroundFrames1)
+  }
+
   func testReplacingHeader() {
     modelState.removeHeader(forSectionAtIndex: 0)
 


### PR DESCRIPTION
## Details

This PR fixes an issue that causes items to be laid out incorrectly.

Details:
- MagazineLayout can calculate the layout starting at a specific item index, which can be anywhere in the layout
- In this scenario, MagazineLayout needs to know if the starting index is for an item in a new row, or an existing row of items
- If our starting index is in an existing row of items, we need all of our calculations to be based on the metrics of the row we're in

The bug was caused by us not looking for the tallest item in the row we're currently laying out - instead, we assumed the item at the starting index of layout was the tallest item, which might not be true. This caused the next row of items to start laying out at a y offset that was too small, resulting in overlapping items.

## Related Issue

https://github.com/airbnb/MagazineLayout/issues/40

## Motivation and Context

N/A, layout bugs must be fixed ;) 

## How Has This Been Tested

Added automated testing to catch this kind of issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.