### PR TITLE
Fix minor item inset layout bug

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.3</string>
+	<string>1.4.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.3'
+  s.version  = '1.4.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -361,9 +361,6 @@ struct SectionModel {
       currentY += newHeaderItemModel.size.height
     }
 
-    // Apply top item inset now that we're laying out items
-    currentY += metrics.itemInsets.top
-
     var indexInCurrentRow = 0
     var stretchToTallestItemInRowItemIndicesInCurrentRow = Set<Int>()
     var heightOfTallestItemInCurrentRow = CGFloat(0)
@@ -447,6 +444,11 @@ struct SectionModel {
         }
       }
 
+      if itemIndex == 0 {
+        // Apply top item inset now that we're laying out items
+        currentY += metrics.itemInsets.top
+      }
+
       let currentLeadingMargin: CGFloat
       let availableWidthForItems: CGFloat
       if itemModel.sizeMode.widthMode == .fullWidth(respectsHorizontalInsets: false) {
@@ -496,7 +498,11 @@ struct SectionModel {
     }
 
     // Update the current caluclated height
-    currentY = currentHeight + metrics.itemInsets.bottom
+    currentY = currentHeight
+    if numberOfItems > 0 {
+      // Apply bottom item inset now that we're done laying out items
+      currentY += metrics.itemInsets.bottom
+    }
     currentHeight = currentY
 
     // Update the footer item

--- a/Tests/ModelStateEmptySectionLayoutTests.swift
+++ b/Tests/ModelStateEmptySectionLayoutTests.swift
@@ -54,9 +54,11 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
       ]
     modelState.setSections(initialSections)
 
+    let expectedHeightOfSection0 = metrics0.sectionInsets.top + metrics0.sectionInsets.bottom
+    let expectedHeightOfSection1 = metrics1.sectionInsets.top + metrics1.sectionInsets.bottom
     XCTAssert(
-      (modelState.sectionMaxY(forSectionAtIndex: 0, .afterUpdates) == 30 &&
-       modelState.sectionMaxY(forSectionAtIndex: 1, .afterUpdates) == 30 + 145),
+      (modelState.sectionMaxY(forSectionAtIndex: 0, .afterUpdates) == expectedHeightOfSection0 &&
+       modelState.sectionMaxY(forSectionAtIndex: 1, .afterUpdates) == expectedHeightOfSection1),
       "The layout has incorrect heights for its sections")
   }
 
@@ -87,7 +89,7 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
 
     let expectedHeaderFrames = [
       CGRect(x: 5, y: 10, width: 310, height: 45),
-      CGRect(x: 0, y: 150, width: 320, height: 65),
+      CGRect(x: 0, y: 120, width: 320, height: 65),
     ]
     XCTAssert(
       FrameHelpers.expectedFrames(
@@ -97,8 +99,8 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
       "Header frames are incorrect")
 
     let expectedFooterFrames = [
-      CGRect(x: 5, y: 85, width: 310, height: 45),
-      CGRect(x: 0, y: 365, width: 320, height: 65)
+      CGRect(x: 5, y: 55, width: 310, height: 45),
+      CGRect(x: 0, y: 185, width: 320, height: 65)
     ]
     XCTAssert(
       FrameHelpers.expectedFrames(
@@ -109,8 +111,8 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
       "Footer frames are incorrect")
 
     let expectedBackgroundFrames = [
-      CGRect(x: 5, y: 10, width: 310, height: 120),
-      CGRect(x: 0, y: 150, width: 320, height: 280),
+      CGRect(x: 5, y: 10, width: 310, height: 90),
+      CGRect(x: 0, y: 120, width: 320, height: 130),
     ]
     XCTAssert(
       FrameHelpers.expectedFrames(


### PR DESCRIPTION
## Details

When a section contains 0 items, item insets should not be used in the layout calculations / contribute to the total height of the layout. This fixes that bug and updates the empty section test cases accordingly.


## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

While working on a refactor of the layout logic, I noticed that I was failing some empty section tests. I was confident in my refactored code, and realized that I had actually fixed this bug in the refactor 🙃 I want to get this merged before the refactor PR that way the refactor PR doesn't have to change any test cases.

## How Has This Been Tested

Changed existing tests to catch this kind of regression.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.