### PR TITLE
Bk/layout calculation rows refactor

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.4</string>
+	<string>1.4.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.4'
+  s.version  = '1.4.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'


### PR DESCRIPTION
## Details

This refactors the core layout / positioning logic in `SectionModel`. The main difference is that some bookkeeping is done to maintain a mapping of item indices and row indices, allowing for us to easily look up the row index for a particular item index, or what item indices are in a particular row. This kind of information is not only useful in the layout calculation itself, but also for future performance optimization work.

## Related Issue

N/A

## Motivation and Context

The concept of "rows" has always been useful to us, but before this refactor, figuring out what items were in the same row as another item involved complicated logic to look ahead and backwards in the array of item models. By storing off this information as we calculate the layout, we can simplify the layout code quite a bit, and also setup the foundational data structures that will be used in an upcoming performance optimization change.

## How Has This Been Tested

All unit tests pass. I also manually tested in the sample app and in the Airbnb app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
