### PR TITLE
Bk/lazy preferred height updating 2

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.5</string>
+	<string>1.4.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.5'
+  s.version  = '1.4.6'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */; };
 		93424B012256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */; };
+		9398462A2296864200E442DA /* RowOffsetTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939846292296864200E442DA /* RowOffsetTracker.swift */; };
 		93A1BFF921ACE9A000DED67D /* MagazineLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A1BFEF21ACE9A000DED67D /* MagazineLayout.framework */; };
 		93A1C03521ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1C01621ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift */; };
 		93A1C03621ACED0100DED67D /* MagazineLayout+SupplementaryViewKinds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1C01721ACED0100DED67D /* MagazineLayout+SupplementaryViewKinds.swift */; };
@@ -50,7 +52,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowOffsetTrackerTests.swift; sourceTree = "<group>"; };
 		93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutFooterVisibilityMode.swift; sourceTree = "<group>"; };
+		939846292296864200E442DA /* RowOffsetTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowOffsetTracker.swift; sourceTree = "<group>"; };
 		93A1BFEF21ACE9A000DED67D /* MagazineLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MagazineLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		93A1BFF821ACE9A000DED67D /* MagazineLayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MagazineLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		93A1C00A21ACED0100DED67D /* ModelStateEmptySectionLayoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelStateEmptySectionLayoutTests.swift; sourceTree = "<group>"; };
@@ -136,6 +140,7 @@
 				93A1C00D21ACED0100DED67D /* ModelStateLayoutTests.swift */,
 				93A1C01021ACED0100DED67D /* ModelStateUpdateTests.swift */,
 				93A1C00F21ACED0100DED67D /* ElementLocationFramePairsTests.swift */,
+				9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */,
 				93A1C00E21ACED0100DED67D /* TestingSupport.swift */,
 			);
 			path = Tests;
@@ -198,6 +203,7 @@
 				93A1C02321ACED0100DED67D /* CollectionViewUpdateItem.swift */,
 				93A1C02121ACED0100DED67D /* ElementLocation.swift */,
 				93A1C02521ACED0100DED67D /* ElementLocationFramePairs.swift */,
+				939846292296864200E442DA /* RowOffsetTracker.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -330,6 +336,7 @@
 				93A1C04421ACED0100DED67D /* SectionModel.swift in Sources */,
 				93A1C03E21ACED0100DED67D /* ElementLocation.swift in Sources */,
 				93A1C04821ACED0100DED67D /* ModelState.swift in Sources */,
+				9398462A2296864200E442DA /* RowOffsetTracker.swift in Sources */,
 				FD4DFF0821B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift in Sources */,
 				93424B012256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift in Sources */,
 				FDF6E15B21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift in Sources */,
@@ -349,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				93A1C04B21ACED1100DED67D /* ModelStateInitiallSetUpTests.swift in Sources */,
+				9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */,
 				93A1C04C21ACED1100DED67D /* ModelStateLayoutTests.swift in Sources */,
 				93A1C04921ACED1100DED67D /* ModelStateEmptySectionLayoutTests.swift in Sources */,
 				93A1C04F21ACED1100DED67D /* ModelStateUpdateTests.swift in Sources */,

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -297,8 +297,7 @@ final class ModelState {
         return 0
       }
 
-      let sectionModels = sectionModelsPointer.assumingMemoryBound(
-        to: SectionModel.self)
+      let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
       var totalHeight: CGFloat = 0
       for sectionIndex in 0...targetSectionIndex {
@@ -339,8 +338,7 @@ final class ModelState {
     }
 
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
-    let sectionModels = sectionModelsPointer.assumingMemoryBound(
-      to: SectionModel.self)
+    let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
     var itemFrame = sectionModels[itemLocation.sectionIndex].calculateFrameForItem(
       atIndex: itemLocation.elementIndex)
@@ -362,8 +360,7 @@ final class ModelState {
     }
 
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
-    let sectionModels = sectionModelsPointer.assumingMemoryBound(
-      to: SectionModel.self)
+    let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
     var headerFrame = sectionModels[sectionIndex].calculateFrameForHeader()
     headerFrame?.origin.y += sectionMinY
@@ -383,8 +380,7 @@ final class ModelState {
     }
 
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
-    let sectionModels = sectionModelsPointer.assumingMemoryBound(
-      to: SectionModel.self)
+    let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
     var footerFrame = sectionModels[sectionIndex].calculateFrameForFooter()
     footerFrame?.origin.y += sectionMinY
@@ -404,8 +400,7 @@ final class ModelState {
     }
 
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
-    let sectionModels = sectionModelsPointer.assumingMemoryBound(
-      to: SectionModel.self)
+    let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
     var backgroundFrame = sectionModels[sectionIndex].calculateFrameForBackground()
     backgroundFrame?.origin.y += sectionMinY
@@ -729,7 +724,7 @@ final class ModelState {
     -> UnsafeMutableRawPointer
   {
     // Accessing these arrays using unsafe, untyped (raw) pointers
-    // avoids expensive copy-on-writes and Swift retain / releases calls.
+    // avoids expensive copy-on-writes and Swift retain / release calls.
     switch batchUpdateStage {
     case .beforeUpdates: return UnsafeMutableRawPointer(mutating: &sectionModelsBeforeBatchUpdates)
     case .afterUpdates: return UnsafeMutableRawPointer(mutating: &currentSectionModels)

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -70,7 +70,21 @@ struct SectionModel {
 
   mutating func calculateHeight() -> CGFloat {
     calculateElementFramesIfNecessary()
+    
     return calculatedHeight
+  }
+
+  mutating func calculateFrameForItem(atIndex index: Int) -> CGRect {
+    calculateElementFramesIfNecessary()
+
+    var origin = itemModels[index].originInSection
+    if let rowIndex = rowIndicesForItemIndices[index] {
+      origin.y += rowOffsetTracker.offsetForRow(at: rowIndex)
+    } else {
+      assertionFailure("Expected a row and a row height for item at \(index).")
+    }
+
+    return CGRect(origin: origin, size: itemModels[index].size)
   }
 
   mutating func calculateFrameForHeader() -> CGRect? {
@@ -78,13 +92,11 @@ struct SectionModel {
 
     calculateElementFramesIfNecessary()
 
-    // `headerModel` is a value type that might be mutated in `recomputeItemPositionsIfNecessary`,
+    // `headerModel` is a value type that might be mutated in `calculateElementFramesIfNecessary`,
     // so we can't use a copy made before that code executes (for example, in a
     // `guard let headerModel = headerModel else { ... }` at the top of this function).
     if let headerModel = headerModel {
-      return CGRect(
-        origin: CGPoint(x: headerModel.originInSection.x, y: headerModel.originInSection.y),
-        size: headerModel.size)
+      return CGRect(origin: headerModel.originInSection, size: headerModel.size)
     } else {
       return nil
     }
@@ -95,27 +107,34 @@ struct SectionModel {
 
     calculateElementFramesIfNecessary()
 
-    // `footerModel` is a value type that might be mutated in `recomputeItemPositionsIfNecessary`,
+    var origin = footerModel?.originInSection
+    if let rowIndex = indexOfFooterRow() {
+      origin?.y += rowOffsetTracker.offsetForRow(at: rowIndex)
+    } else {
+      assertionFailure("Expected a row and a corresponding section footer.")
+    }
+
+    // `footerModel` is a value type that might be mutated in `calculateElementFramesIfNecessary`,
     // so we can't use a copy made before that code executes (for example, in a
     // `guard let footerModel = footerModel else { ... }` at the top of this function).
     if let footerModel = footerModel {
-      return CGRect(
-        origin: CGPoint(x: footerModel.originInSection.x, y: footerModel.originInSection.y),
-        size: footerModel.size)
+      return CGRect(origin: origin ?? footerModel.originInSection, size: footerModel.size)
     } else {
       return nil
     }
   }
 
   mutating func calculateFrameForBackground() -> CGRect? {
-    guard backgroundModel != nil else { return nil }
+    let calculatedHeight = calculateHeight()
 
-    calculateElementFramesIfNecessary()
+    backgroundModel?.originInSection = CGPoint(
+      x: metrics.sectionInsets.left,
+      y: metrics.sectionInsets.top)
+    backgroundModel?.size.width = metrics.width
+    backgroundModel?.size.height = calculatedHeight -
+      metrics.sectionInsets.top -
+      metrics.sectionInsets.bottom
 
-    // `backgroundModel` is a value type that might be mutated in
-    // `recomputeItemPositionsIfNecessary`, so we can't use a copy made before that code executes
-    // (for example, in a `guard let backgroundModel = backgroundModel else { ... }` at the top of
-    // this function).
     if let backgroundModel = backgroundModel {
       return CGRect(
         origin: CGPoint(x: backgroundModel.originInSection.x, y: backgroundModel.originInSection.y),
@@ -123,12 +142,6 @@ struct SectionModel {
     } else {
       return nil
     }
-  }
-
-  mutating func calculateFrameForItem(atIndex itemIndex: Int) -> CGRect {
-    calculateElementFramesIfNecessary()
-
-    return frameForItem(atIndex: itemIndex)
   }
 
   @discardableResult
@@ -154,31 +167,15 @@ struct SectionModel {
 
   mutating func updateItemSizeMode(to sizeMode: MagazineLayoutItemSizeMode, atIndex index: Int) {
     // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
-    // and Swift retain / releases calls.
+    // and Swift retain / release calls.
     let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
-    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(
-      to: ItemModel.self)
+    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(to: ItemModel.self)
 
     directlyMutableItemModels[index].sizeMode = sizeMode
 
     if case let .static(staticHeight) = sizeMode.heightMode {
       directlyMutableItemModels[index].size.height = staticHeight
     }
-
-    updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex: index)
-  }
-
-  mutating func updateItemHeight(
-    toPreferredHeight preferredHeight: CGFloat,
-    atIndex index: Int)
-  {
-    // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
-    // and Swift retain / releases calls.
-    let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
-    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(
-      to: ItemModel.self)
-
-    directlyMutableItemModels[index].preferredHeight = preferredHeight
 
     updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex: index)
   }
@@ -229,32 +226,81 @@ struct SectionModel {
     footerModel = nil
   }
 
+  mutating func updateItemHeight(toPreferredHeight preferredHeight: CGFloat, atIndex index: Int) {
+    // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
+    // and Swift retain / release calls.
+    let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
+    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(to: ItemModel.self)
+
+    directlyMutableItemModels[index].preferredHeight = preferredHeight
+
+    if
+      let rowIndex = rowIndicesForItemIndices[index],
+      let rowHeight = itemRowHeightsForRowIndices[rowIndex]
+    {
+      let newRowHeight = updateHeightsForItemsInRow(at: rowIndex)
+      let heightDelta = newRowHeight - rowHeight
+
+      calculatedHeight += heightDelta
+
+      let firstAffectedRowIndex = rowIndex + 1
+      if firstAffectedRowIndex < numberOfRows {
+        rowOffsetTracker.addOffset(heightDelta, forRowsStartingAt: firstAffectedRowIndex)
+      }
+    } else {
+      assertionFailure("Expected a row and a row height for item at \(index).")
+      return
+    }
+  }
+
   mutating func updateHeaderHeight(toPreferredHeight preferredHeight: CGFloat) {
     headerModel?.preferredHeight = preferredHeight
 
-    if let indexOfHeader = indexOfHeaderRow() {
-      updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfHeader)
+    if let indexOfHeaderRow = indexOfHeaderRow(), let headerModel = headerModel {
+      let rowHeight = headerModel.size.height
+      let newRowHeight = updateHeaderHeight(withMetricsFrom: headerModel)
+      let heightDelta = newRowHeight - rowHeight
+      
+      calculatedHeight += heightDelta
+      
+      let firstAffectedRowIndex = indexOfHeaderRow + 1
+      if firstAffectedRowIndex < numberOfRows {
+        rowOffsetTracker.addOffset(heightDelta, forRowsStartingAt: firstAffectedRowIndex)
+      }
+    } else {
+      assertionFailure("Expected a row, a row height, and a corresponding section header.")
+      return
     }
   }
 
   mutating func updateFooterHeight(toPreferredHeight preferredHeight: CGFloat) {
     footerModel?.preferredHeight = preferredHeight
 
-    if let indexOfFooter = indexOfFooterRow() {
-      updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfFooter)
+    if let indexOfFooterRow = indexOfFooterRow(), let footerModel = footerModel {
+      let rowHeight = footerModel.size.height
+      let newRowHeight = updateFooterHeight(withMetricsFrom: footerModel)
+      let heightDelta = newRowHeight - rowHeight
+    
+      calculatedHeight += heightDelta
+      
+      let firstAffectedRowIndex = indexOfFooterRow + 1
+      if firstAffectedRowIndex < numberOfRows {
+        rowOffsetTracker.addOffset(heightDelta, forRowsStartingAt: firstAffectedRowIndex)
+      }
+    } else {
+      assertionFailure("Expected a row, a row height, and a corresponding section footer.")
+      return
     }
   }
-
+      
   mutating func setBackground(_ backgroundModel: BackgroundModel) {
     self.backgroundModel = backgroundModel
-
-    let indexOfLastRow = indexOfFooterRow() ?? indexOfLastItemsRow() ?? indexOfHeaderRow() ?? -1
-    updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfLastRow + 1)
+    // No need to invalidate since the background doesn't affect the layout.
   }
 
   mutating func removeBackground() {
     backgroundModel = nil
-    // No need to invalidate since no frames will be adjusted
+    // No need to invalidate since the background doesn't affect the layout.
   }
 
   // MARK: Private
@@ -266,23 +312,14 @@ struct SectionModel {
   private var indexOfFirstInvalidatedRow: Int?
   private var itemIndicesForRowIndices = [Int: [Int]]()
   private var rowIndicesForItemIndices = [Int: Int]()
+  private var itemRowHeightsForRowIndices = [Int: CGFloat]()
 
-  private mutating func updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex changedIndex: Int) {
-    guard
-      let indexOfCurrentRow = rowIndicesForItemIndices[changedIndex],
-      indexOfCurrentRow > 0 else
-    {
-      indexOfFirstInvalidatedRow = rowIndicesForItemIndices[0] ?? 0
-      return
-    }
+  private var rowOffsetTracker = RowOffsetTracker(numberOfRows: 0)
 
-    updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfCurrentRow - 1)
-  }
-
-  private mutating func updateIndexOfFirstInvalidatedRowIfNecessary(
-    toProposedIndex proposedIndex: Int)
-  {
-    indexOfFirstInvalidatedRow = min(proposedIndex, indexOfFirstInvalidatedRow ?? proposedIndex)
+  private var numberOfRows: Int {
+    return (headerModel != nil ? 1 : 0) +
+      itemIndicesForRowIndices.count +
+      (footerModel != nil ? 1 : 0)
   }
 
   private func maxYForItemsRow(atIndex rowIndex: Int) -> CGFloat? {
@@ -316,15 +353,23 @@ struct SectionModel {
     guard footerModel != nil else { return nil }
     return (indexOfLastItemsRow() ?? indexOfHeaderRow() ?? -1) + 1
   }
-
-  private func frameForItem(atIndex itemIndex: Int) -> CGRect {
-    let itemModel = itemModels[itemIndex]
-
-    return CGRect(
-      origin: CGPoint(
-        x: itemModel.originInSection.x,
-        y: itemModel.originInSection.y),
-      size: itemModel.size)
+  
+  private mutating func updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex changedIndex: Int) {
+    guard
+      let indexOfCurrentRow = rowIndicesForItemIndices[changedIndex],
+      indexOfCurrentRow > 0 else
+    {
+      indexOfFirstInvalidatedRow = rowIndicesForItemIndices[0] ?? 0
+      return
+    }
+    
+    updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfCurrentRow - 1)
+  }
+  
+  private mutating func updateIndexOfFirstInvalidatedRowIfNecessary(
+    toProposedIndex proposedIndex: Int)
+  {
+    indexOfFirstInvalidatedRow = min(proposedIndex, indexOfFirstInvalidatedRow ?? proposedIndex)
   }
 
   private mutating func calculateElementFramesIfNecessary() {
@@ -334,9 +379,10 @@ struct SectionModel {
       return
     }
 
-    // Clean up item / row index mappings starting at our `indexOfFirstInvalidatedRow`; we'll make
-    // new mappings for those row indices as we do layout calculations below. Since all item / row
-    // index mappings before `indexOfFirstInvalidatedRow` are still valid, we'll leave those alone.
+    // Clean up item / row / height mappings starting at our `indexOfFirstInvalidatedRow`; we'll
+    // make new mappings for those row indices as we do layout calculations below. Since all
+    // item / row index mappings before `indexOfFirstInvalidatedRow` are still valid, we'll leave
+    // those alone.
     for rowIndexKey in itemIndicesForRowIndices.keys {
       guard rowIndexKey >= rowIndex else { continue }
 
@@ -345,16 +391,17 @@ struct SectionModel {
       }
 
       itemIndicesForRowIndices[rowIndexKey] = nil
+      itemRowHeightsForRowIndices[rowIndex] = nil
     }
 
     // Header frame calculation
-    if rowIndex == indexOfHeaderRow(), var newHeaderItemModel = headerModel {
-      newHeaderItemModel.originInSection = CGPoint(
+    if rowIndex == indexOfHeaderRow(), var headerModel = headerModel {
+      headerModel.originInSection = CGPoint(
         x: metrics.sectionInsets.left,
         y: metrics.sectionInsets.top)
-      newHeaderItemModel.size.width = metrics.width
-      newHeaderItemModel.size.height = newHeaderItemModel.preferredHeight ?? newHeaderItemModel.size.height
-      headerModel = newHeaderItemModel
+      headerModel.size.width = metrics.width
+      updateHeaderHeight(withMetricsFrom: headerModel)
+      self.headerModel = headerModel
 
       rowIndex = 1
     }
@@ -393,10 +440,12 @@ struct SectionModel {
       }
     }
 
-    var indexInCurrentRow = 0
-    var heightOfTallestItemInCurrentRow = CGFloat(0)
-    var stretchToTallestItemInRowItemIndicesInCurrentRow = Set<Int>()
+    // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
+    // and Swift retain / release calls.
+    let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
+    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(to: ItemModel.self)
 
+    var indexInCurrentRow = 0
     for itemIndex in startingItemIndex..<numberOfItems {
       // Create item / row index mappings
       itemIndicesForRowIndices[rowIndex] = itemIndicesForRowIndices[rowIndex] ?? []
@@ -428,42 +477,21 @@ struct SectionModel {
         metrics.horizontalSpacing + currentLeadingMargin
       let itemY = currentY
 
-      // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
-      // and Swift retain / release calls.
-      let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
-      let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(to: ItemModel.self)
-
       directlyMutableItemModels[itemIndex].originInSection = CGPoint(x: itemX, y: itemY)
       directlyMutableItemModels[itemIndex].size.width = itemWidth
-      directlyMutableItemModels[itemIndex].size.height = itemModel.preferredHeight ?? itemModel.size.height
-
-      // Handle stretch to tallest item in row height mode for current row
-
-      if itemModel.sizeMode.heightMode == .dynamicAndStretchToTallestItemInRow {
-        stretchToTallestItemInRowItemIndicesInCurrentRow.insert(itemIndex)
-      }
-
-      heightOfTallestItemInCurrentRow = max(
-        heightOfTallestItemInCurrentRow,
-        itemModels[itemIndex].size.height)
-
-      for stretchToTallestItemInRowItemIndex in stretchToTallestItemInRowItemIndicesInCurrentRow {
-        directlyMutableItemModels[stretchToTallestItemInRowItemIndex].size.height = heightOfTallestItemInCurrentRow
-      }
 
       if
         (indexInCurrentRow == Int(itemModel.sizeMode.widthMode.widthDivisor) - 1) ||
-        (itemIndex == numberOfItems - 1) ||
-        (itemIndex < numberOfItems - 1 && itemModels[itemIndex + 1].sizeMode.widthMode != itemModel.sizeMode.widthMode)
+          (itemIndex == numberOfItems - 1) ||
+          (itemIndex < numberOfItems - 1 && itemModels[itemIndex + 1].sizeMode.widthMode != itemModel.sizeMode.widthMode)
       {
         // We've reached the end of the current row, or there are no more items to lay out, or we're
         // about to lay out an item with a different width mode. In all cases, we're done laying out
         // the current row of items.
+        let heightOfTallestItemInCurrentRow = updateHeightsForItemsInRow(at: rowIndex)
         currentY += heightOfTallestItemInCurrentRow
         rowIndex += 1
         indexInCurrentRow = 0
-        heightOfTallestItemInCurrentRow = 0
-        stretchToTallestItemInRowItemIndicesInCurrentRow.removeAll()
 
         // If there are more items to layout, add vertical spacing
         if itemIndex < numberOfItems - 1 {
@@ -481,26 +509,73 @@ struct SectionModel {
     }
 
     // Footer frame calculations
-    if rowIndex == indexOfFooterRow(), var newFooterModel = footerModel {
-      newFooterModel.originInSection = CGPoint(x: metrics.sectionInsets.left, y: currentY)
-      newFooterModel.size.width = metrics.width
-      newFooterModel.size.height = newFooterModel.preferredHeight ?? newFooterModel.size.height
-      footerModel = newFooterModel
+    if rowIndex == indexOfFooterRow(), var footerModel = footerModel {
+      footerModel.originInSection = CGPoint(x: metrics.sectionInsets.left, y: currentY)
+      footerModel.size.width = metrics.width
+      updateFooterHeight(withMetricsFrom: footerModel)
+      self.footerModel = footerModel
     }
 
     // Final height calculation
     calculatedHeight = currentY + (footerModel?.size.height ?? 0) + metrics.sectionInsets.bottom
 
-    // Background frame calculations
-    backgroundModel?.originInSection = CGPoint(
-      x: metrics.sectionInsets.left,
-      y: metrics.sectionInsets.top)
-    backgroundModel?.size.width = metrics.width
-    backgroundModel?.size.height = calculatedHeight -
-      metrics.sectionInsets.top -
-      metrics.sectionInsets.bottom
+    // The background frame is calculated just-in-time, since its value doesn't affect the layout.
 
+    // Create a row offset tracker now that we know how many rows we have
+    rowOffsetTracker = RowOffsetTracker(numberOfRows: numberOfRows)
+
+    // Mark the layout as clean / no longer invalid
     indexOfFirstInvalidatedRow = nil
   }
 
+  private mutating func updateHeightsForItemsInRow(at rowIndex: Int) -> CGFloat {
+    guard let indicesForItemsInRow = itemIndicesForRowIndices[rowIndex] else {
+      assertionFailure("Expected item indices for row \(rowIndex).")
+      return 0
+    }
+
+    // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
+    // and Swift retain / release calls.
+    let itemModelsPointer = UnsafeMutableRawPointer(mutating: &itemModels)
+    let directlyMutableItemModels = itemModelsPointer.assumingMemoryBound(to: ItemModel.self)
+
+    var heightOfTallestItem = CGFloat(0)
+    var stretchToTallestItemInRowItemIndices = Set<Int>()
+
+    for itemIndex in indicesForItemsInRow {
+      let preferredHeight = itemModels[itemIndex].preferredHeight
+      let height = itemModels[itemIndex].size.height
+      directlyMutableItemModels[itemIndex].size.height = preferredHeight ?? height
+
+      // Handle stretch to tallest item in row height mode for current row
+
+      if itemModels[itemIndex].sizeMode.heightMode == .dynamicAndStretchToTallestItemInRow {
+        stretchToTallestItemInRowItemIndices.insert(itemIndex)
+      }
+
+      heightOfTallestItem = max(heightOfTallestItem, itemModels[itemIndex].size.height)
+    }
+
+    for stretchToTallestItemInRowItemIndex in stretchToTallestItemInRowItemIndices{
+      directlyMutableItemModels[stretchToTallestItemInRowItemIndex].size.height = heightOfTallestItem
+    }
+
+    itemRowHeightsForRowIndices[rowIndex] = heightOfTallestItem
+    return heightOfTallestItem
+  }
+  
+  @discardableResult
+  private mutating func updateHeaderHeight(withMetricsFrom headerModel: HeaderModel) -> CGFloat {
+    let height = headerModel.preferredHeight ?? headerModel.size.height
+    self.headerModel?.size.height = height
+    return height
+  }
+  
+  @discardableResult
+  private mutating func updateFooterHeight(withMetricsFrom footerModel: FooterModel) -> CGFloat {
+    let height = footerModel.preferredHeight ?? footerModel.size.height
+    self.footerModel?.size.height = height
+    return height
+  }
+  
 }

--- a/MagazineLayout/LayoutCore/Types/RowOffsetTracker.swift
+++ b/MagazineLayout/LayoutCore/Types/RowOffsetTracker.swift
@@ -1,0 +1,79 @@
+// Created by bryankeller on 5/23/19.
+// Copyright © 2019 Airbnb, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreGraphics
+
+/// Tracks offsets for rows using a Segment Tree for O(log n) lookups and updates.
+struct RowOffsetTracker {
+
+  // MARK: Lifecycle
+
+  init(numberOfRows: Int) {
+    self.numberOfRows = numberOfRows
+
+    rowOffsets = Array(repeating: 0, count: 2 * numberOfRows)
+  }
+
+  // MARK: Internal
+
+  mutating func addOffset(_ offset: CGFloat, forRowsStartingAt rowIndex: Int) {
+    var rowIndex = rowIndex + numberOfRows
+
+    // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
+    // and Swift retain / release calls.
+    let rowOffsetsPointer = UnsafeMutableRawPointer(mutating: &rowOffsets)
+    let directlyMutableRowOffsets = rowOffsetsPointer.assumingMemoryBound(to: CGFloat.self)
+    directlyMutableRowOffsets[rowIndex] = rowOffsets[rowIndex] + offset
+
+    while rowIndex > 1 {
+      rowIndex /= 2
+
+      let leftChild = rowOffsets[2 * rowIndex]
+      let rightChild = rowOffsets[(2 * rowIndex) + 1]
+      directlyMutableRowOffsets[rowIndex] = leftChild + rightChild
+    }
+  }
+
+  func offsetForRow(at rowIndex: Int) -> CGFloat {
+    var lowerBound = numberOfRows
+    var upperBound = rowIndex + numberOfRows + 1
+
+    var offset = CGFloat(0)
+
+    while lowerBound < upperBound {
+      if lowerBound % 2 != 0 {
+        offset += rowOffsets[lowerBound]
+        lowerBound += 1
+      }
+
+      if upperBound % 2 != 0 {
+        upperBound -= 1
+        offset += rowOffsets[upperBound]
+      }
+
+      lowerBound /= 2
+      upperBound /= 2
+    }
+
+    return offset
+  }
+
+  // MARK: Private
+
+  private let numberOfRows: Int
+
+  private var rowOffsets: [CGFloat]
+
+}

--- a/Tests/RowOffsetTrackerTests.swift
+++ b/Tests/RowOffsetTrackerTests.swift
@@ -1,0 +1,97 @@
+// Created by Bryan Keller on 5/23/19.
+// Copyright © 2019 Airbnb Inc. All rights reserved.
+
+import XCTest
+
+@testable import MagazineLayout
+
+final class RowOffsetTrackerTests: XCTestCase {
+
+  // MARK: Internal
+
+  func testOneRow() {
+    var rowOffsetTracker1 = RowOffsetTracker(numberOfRows: 1)
+
+    XCTAssert(rowOffsetTracker1.offsetForRow(at: 0) == 0)
+
+    rowOffsetTracker1.addOffset(-50, forRowsStartingAt: 0)
+    XCTAssert(rowOffsetTracker1.offsetForRow(at: 0) == -50)
+
+    rowOffsetTracker1.addOffset(0, forRowsStartingAt: 0)
+    XCTAssert(rowOffsetTracker1.offsetForRow(at: 0) == -50)
+
+    rowOffsetTracker1.addOffset(50, forRowsStartingAt: 0)
+    XCTAssert(rowOffsetTracker1.offsetForRow(at: 0) == 0)
+  }
+
+  func testTwoRows() {
+    var rowOffsetTracker2 = RowOffsetTracker(numberOfRows: 2)
+
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 0) == 0)
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 1) == 0)
+
+    rowOffsetTracker2.addOffset(10, forRowsStartingAt: 0)
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 0) == 10)
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 1) == 10)
+
+    rowOffsetTracker2.addOffset(-5, forRowsStartingAt: 1)
+    rowOffsetTracker2.addOffset(20, forRowsStartingAt: 0)
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 1) == 25)
+    XCTAssert(rowOffsetTracker2.offsetForRow(at: 0) == 30)
+  }
+
+  func testPowerOfTwoNumberOfRows() {
+    var rowOffsetTracker64 = RowOffsetTracker(numberOfRows: 64)
+
+    XCTAssert(rowOffsetTracker64.offsetForRow(at: 0) == 0)
+    XCTAssert(rowOffsetTracker64.offsetForRow(at: 63) == 0)
+
+    rowOffsetTracker64.addOffset(-50, forRowsStartingAt: 30)
+    rowOffsetTracker64.addOffset(100, forRowsStartingAt: 25)
+    rowOffsetTracker64.addOffset(10, forRowsStartingAt: 63)
+    rowOffsetTracker64.addOffset(10, forRowsStartingAt: 1)
+    rowOffsetTracker64.addOffset(-5, forRowsStartingAt: 0)
+    rowOffsetTracker64.addOffset(60, forRowsStartingAt: 23)
+    rowOffsetTracker64.addOffset(62, forRowsStartingAt: -1)
+
+    let expectedOffsets: [CGFloat] = [
+      -5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+      5.0, 5.0, 5.0, 5.0, 5.0, 65.0, 65.0, 165.0, 165.0, 165.0, 165.0, 165.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 187.0
+    ]
+    for i in 0..<64 {
+      XCTAssert(rowOffsetTracker64.offsetForRow(at: i) == expectedOffsets[i])
+    }
+  }
+
+  func testNonPowerOfTwoNumberOfRows() {
+    var rowOffsetTracker70 = RowOffsetTracker(numberOfRows: 70)
+
+    XCTAssert(rowOffsetTracker70.offsetForRow(at: 0) == 0)
+    XCTAssert(rowOffsetTracker70.offsetForRow(at: 69) == 0)
+
+    rowOffsetTracker70.addOffset(-50, forRowsStartingAt: 30)
+    rowOffsetTracker70.addOffset(100, forRowsStartingAt: 25)
+    rowOffsetTracker70.addOffset(10, forRowsStartingAt: 63)
+    rowOffsetTracker70.addOffset(10, forRowsStartingAt: 1)
+    rowOffsetTracker70.addOffset(-5, forRowsStartingAt: 0)
+    rowOffsetTracker70.addOffset(60, forRowsStartingAt: 23)
+    rowOffsetTracker70.addOffset(62, forRowsStartingAt: -1)
+    rowOffsetTracker70.addOffset(-100, forRowsStartingAt: 65)
+    rowOffsetTracker70.addOffset(0, forRowsStartingAt: 69)
+
+    let expectedOffsets: [CGFloat] = [
+      -5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+      5.0, 5.0, 5.0, 5.0, 5.0, 65.0, 65.0, 165.0, 165.0, 165.0, 165.0, 165.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0, 115.0,
+      115.0, 115.0, 115.0, 115.0, 125.0, 125.0, 25.0, 25.0, 25.0, 25.0, 25.0
+    ]
+    for i in 0..<70 {
+      XCTAssert(rowOffsetTracker70.offsetForRow(at: i) == expectedOffsets[i])
+    }
+  }
+
+}


### PR DESCRIPTION
## Details

**Second attempt at implementing the changes from https://github.com/airbnb/MagazineLayout/pull/47
Commit 1 is identical to #47. Commit 2 has the new code / bug fixes. All performance comparisons below are still accurate.**

This implements a "lazy" approach to applying preferred attributes to elements in the layout. As preferred attributes are received for elements, we look at the resulting height delta for the row that the element is in (there might be multiple items in a single row, or just one), then store the height delta as an offset to apply to all rows beneath us.

Here's an example:
1. All elements have estimated heights
2. Our header received preferred attributes, making its height `100` instead of `50`
3. We store this `+50` height delta, and the index of the first row affected by the change to the header row's height
4. When the layout asks us for the final frame for an item in a row below the header's row, we add `+50` to its y-origin

By using a Segment Tree, we can efficiently store (when we receive preferred attributes) and look up (when we're asked for a frame for an element) `row-index -> y-offset` pairs. In the worst case scenario, it takes `O(logn)` time to store and look up an offset for a particular row index. For example, if there are `1_000_000` rows, it only takes ~19 lookups to figure out how much to add to the last row's y-origin.

## Related Issue

N/A

## Motivation and Context

This greatly improves performance when scrolling if there are many items in the collection view. Scroll-time performance now hovers at ~10% for a layout configuration with 2 items across (half width) and `100_000` items. Previously, `100_000` items pegged the CPU at 90-100%, causing many, many dropped frames.

## Screenshots

#### `MagazineLayout` Before

<img width="1792" alt="Screen Shot 2019-05-23 at 3 09 21 AM" src="https://user-images.githubusercontent.com/746571/58244818-41e13780-7d08-11e9-9a0b-dc236dd5c5cb.png">
 
#### `MagazineLayout` After

<img width="1792" alt="Screen Shot 2019-05-23 at 3 07 53 AM" src="https://user-images.githubusercontent.com/746571/58244831-473e8200-7d08-11e9-9fd9-e1011a11efe8.png">

#### `UICollectionViewFlowLayout` 😅

<img width="1792" alt="Screen Shot 2019-05-23 at 3 06 29 AM" src="https://user-images.githubusercontent.com/746571/58244844-4dccf980-7d08-11e9-8203-d6a7ed1c037e.png">

#### Super fast scrolling

| UICollectionViewFlowLayout | `MagazineLayout` |
| ---- | ---- |
| <img width="1792" alt="Screen Shot 2019-05-23 at 3 22 19 AM" src="https://user-images.githubusercontent.com/746571/58246061-faa87600-7d0a-11e9-8b3d-672c71d3785b.png"> | <img width="1792" alt="Screen Shot 2019-05-23 at 3 27 42 AM" src="https://user-images.githubusercontent.com/746571/58246126-1f045280-7d0b-11e9-8b23-eb6bab65b0d2.png"> |

## How Has This Been Tested

- Automated tests
- Airbnb app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.