### PR TITLE
Bk/supplementary view pinning

### DIFF
--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -93,7 +93,7 @@ final class ViewController: UIViewController {
 
     let section0 = SectionInfo(
       headerInfo: HeaderInfo(
-        visibilityMode: .visible(heightMode: .dynamic),
+        visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: true),
         title: "Welcome!"),
       itemInfos: [
         ItemInfo(
@@ -219,7 +219,7 @@ final class ViewController: UIViewController {
 
     let section1 = SectionInfo(
       headerInfo: HeaderInfo(
-        visibilityMode: .visible(heightMode: .dynamic),
+        visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: false),
         title: "Self-sizing supplementary views (headers and footers) are also supported."),
       itemInfos: [
         ItemInfo(
@@ -261,7 +261,7 @@ final class ViewController: UIViewController {
 
     let section2 = SectionInfo(
       headerInfo: HeaderInfo(
-        visibilityMode: .visible(heightMode: .dynamic),
+        visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: false),
         title: "Using this app:"),
       itemInfos: [
         ItemInfo(
@@ -302,7 +302,7 @@ final class ViewController: UIViewController {
           color: Colors.green),
       ],
       footerInfo: FooterInfo(
-        visibilityMode: .visible(heightMode: .dynamic),
+        visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: true),
         title: "Enjoy using MagazineLayout!"),
       backgroundInfo: BackgroundInfo(visibilityMode: .hidden)
     )
@@ -375,11 +375,11 @@ final class ViewController: UIViewController {
           } else {
             let sectionInfo = SectionInfo(
               headerInfo: HeaderInfo(
-                visibilityMode: .visible(heightMode: .dynamic),
+                visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: true),
                 title: "Header"),
               itemInfos: [itemInfo],
               footerInfo: FooterInfo(
-                visibilityMode: .visible(heightMode: .dynamic),
+                visibilityMode: .visible(heightMode: .dynamic, pinToVisibleBounds: true),
                 title: "Footer"),
               backgroundInfo: BackgroundInfo(visibilityMode: .hidden)
             )

--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.6</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.4.6'
+  s.version  = '1.5.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/FooterModel.swift
+++ b/MagazineLayout/LayoutCore/FooterModel.swift
@@ -20,8 +20,9 @@ struct FooterModel {
 
   // MARK: Lifecycle
 
-  init(heightMode: MagazineLayoutFooterHeightMode, height: CGFloat) {
+  init(heightMode: MagazineLayoutFooterHeightMode, height: CGFloat, pinToVisibleBounds: Bool) {
     self.heightMode = heightMode
+    self.pinToVisibleBounds = pinToVisibleBounds
     originInSection = .zero
     size = CGSize(width: 0, height: height)
   }
@@ -29,6 +30,7 @@ struct FooterModel {
   // MARK: Internal
 
   var heightMode: MagazineLayoutFooterHeightMode
+  var pinToVisibleBounds: Bool
   var originInSection: CGPoint
   var size: CGSize
   var preferredHeight: CGFloat?

--- a/MagazineLayout/LayoutCore/HeaderModel.swift
+++ b/MagazineLayout/LayoutCore/HeaderModel.swift
@@ -21,8 +21,9 @@ struct HeaderModel {
 
   // MARK: Lifecycle
 
-  init(heightMode: MagazineLayoutHeaderHeightMode, height: CGFloat) {
+  init(heightMode: MagazineLayoutHeaderHeightMode, height: CGFloat, pinToVisibleBounds: Bool) {
     self.heightMode = heightMode
+    self.pinToVisibleBounds = pinToVisibleBounds
     originInSection = .zero
     size = CGSize(width: 0, height: height)
   }
@@ -30,6 +31,7 @@ struct HeaderModel {
   // MARK: Internal
 
   var heightMode: MagazineLayoutHeaderHeightMode
+  var pinToVisibleBounds: Bool
   var originInSection: CGPoint
   var size: CGSize
   var preferredHeight: CGFloat?

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -19,6 +19,12 @@ import Foundation
 /// Manages the state of section and element models.
 final class ModelState {
 
+  // MARK: Lifecycle
+
+  init(currentVisibleBoundsProvider: @escaping () -> CGRect) {
+    self.currentVisibleBoundsProvider = currentVisibleBoundsProvider
+  }
+
   // MARK: Internal
 
   enum BatchUpdateStage {
@@ -362,7 +368,13 @@ final class ModelState {
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
     let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
-    var headerFrame = sectionModels[sectionIndex].calculateFrameForHeader()
+    let currentVisibleBounds = currentVisibleBoundsProvider()
+    var headerFrame = sectionModels[sectionIndex].calculateFrameForHeader(
+      inSectionVisibleBounds: CGRect(
+        x: currentVisibleBounds.minX,
+        y: currentVisibleBounds.minY - sectionMinY,
+        width: currentVisibleBounds.width,
+        height: currentVisibleBounds.height))
     headerFrame?.origin.y += sectionMinY
     return headerFrame
   }
@@ -382,7 +394,13 @@ final class ModelState {
     let sectionModelsPointer = self.sectionModelsPointer(batchUpdateStage)
     let sectionModels = sectionModelsPointer.assumingMemoryBound(to: SectionModel.self)
 
-    var footerFrame = sectionModels[sectionIndex].calculateFrameForFooter()
+    let currentVisibleBounds = currentVisibleBoundsProvider()
+    var footerFrame = sectionModels[sectionIndex].calculateFrameForFooter(
+      inSectionVisibleBounds: CGRect(
+        x: currentVisibleBounds.minX,
+        y: currentVisibleBounds.minY - sectionMinY,
+        width: currentVisibleBounds.width,
+        height: currentVisibleBounds.height))
     footerFrame?.origin.y += sectionMinY
     return footerFrame
   }
@@ -701,6 +719,8 @@ final class ModelState {
     case updateCurrentModels
     case updatePreviousAndCurrentModels(previousSectionIndex: Int, currentSectionIndex: Int)
   }
+
+  private let currentVisibleBoundsProvider: () -> CGRect
 
   private var currentSectionModels = [SectionModel]()
   private var sectionModelsBeforeBatchUpdates = [SectionModel]()

--- a/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
@@ -27,6 +27,15 @@ public enum MagazineLayoutFooterVisibilityMode {
   /// This visibility mode will cause the footer to not be visibile in its respective section.
   case hidden
 
+  /// This visibility mode will cause the footer to be displayed using the specified height mode in
+  /// its respective section.
+  public static func visible(
+    heightMode: MagazineLayoutFooterHeightMode)
+    -> MagazineLayoutFooterVisibilityMode
+  {
+    return .visible(heightMode: heightMode, pinToVisibleBounds: false)
+  }
+
 }
 
 // MARK: - MagazineLayoutFooterHeightMode

--- a/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
@@ -20,8 +20,9 @@ import CoreGraphics
 public enum MagazineLayoutFooterVisibilityMode {
 
   /// This visibility mode will cause the footer to be displayed using the specified height mode in
-  /// its respective section.
-  case visible(heightMode: MagazineLayoutFooterHeightMode)
+  /// its respective section. If `pinToVisibleBounds` is true, the footer will pin to the visible
+  /// bounds of the collection view while its containing section is visible.
+  case visible(heightMode: MagazineLayoutFooterHeightMode, pinToVisibleBounds: Bool)
 
   /// This visibility mode will cause the footer to not be visibile in its respective section.
   case hidden

--- a/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
@@ -21,8 +21,9 @@ import CoreGraphics
 public enum MagazineLayoutHeaderVisibilityMode {
 
   /// This visibility mode will cause the header to be displayed using the specified height mode in
-  /// its respective section.
-  case visible(heightMode: MagazineLayoutHeaderHeightMode)
+  /// its respective section. If `pinToVisibleBounds` is true, the header will pin to the visible
+  /// bounds of the collection view while its containing section is visible.
+  case visible(heightMode: MagazineLayoutHeaderHeightMode, pinToVisibleBounds: Bool)
 
   /// This visibility mode will cause the header to not be visibile in its respective section.
   case hidden

--- a/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
@@ -28,6 +28,15 @@ public enum MagazineLayoutHeaderVisibilityMode {
   /// This visibility mode will cause the header to not be visibile in its respective section.
   case hidden
 
+  /// This visibility mode will cause the header to be displayed using the specified height mode in
+  /// its respective section.
+  public static func visible(
+    heightMode: MagazineLayoutHeaderHeightMode)
+    -> MagazineLayoutHeaderVisibilityMode
+  {
+    return .visible(heightMode: heightMode, pinToVisibleBounds: false)
+  }
+
 }
 
 // MARK: - MagazineLayoutHeaderHeightMode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A collection view layout capable of laying out views in vertically scrolling gri
 - Per-item self-sizing preferences (self-size and statically-size items anywhere in your collection view)
 - Self-sizing headers and footers
 - Hiding or showing headers and footers on a per-section basis
+- Pinned (sticky) headers and footers
 - Section backgrounds that can be hidden / visible on a per-section basis
 
 Other features:
@@ -192,7 +193,7 @@ collectionView.delegate = self
 Here's an example delegate implementation:
 
 ```swift
-extension  ViewController: UICollectionViewDelegateMagazineLayout {
+extension ViewController: UICollectionViewDelegateMagazineLayout {
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeModeForItemAt indexPath: IndexPath) -> MagazineLayoutItemSizeMode {
     let widthMode = MagazineLayoutItemWidthMode.halfWidth
@@ -201,11 +202,11 @@ extension  ViewController: UICollectionViewDelegateMagazineLayout {
   }
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, visibilityModeForHeaderInSectionAtIndex index: Int) -> MagazineLayoutSupplementaryViewVisibilityMode {
-    return .visible(heightMode: .dynamic)
+    return .visible(heightMode: .dynamic, pinToVisibleBounds: true)
   }
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, visibilityModeForFooterInSectionAtIndex index: Int) -> MagazineLayoutSupplementaryViewVisibilityMode {
-    return .visible(heightMode: .dynamic)
+    return .visible(heightMode: .dynamic, pinToVisibleBounds: false)
   }
 
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, visibilityModeForBackgroundInSectionAtIndex index: Int) -> MagazineLayoutBackgroundVisibilityMode {

--- a/Tests/ModelStateEmptySectionLayoutTests.swift
+++ b/Tests/ModelStateEmptySectionLayoutTests.swift
@@ -22,7 +22,7 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
   // MARK: Internal
 
   override func setUp() {
-    modelState = ModelState()
+    modelState = ModelState(currentVisibleBoundsProvider: { return .zero })
   }
 
   override func tearDown() {
@@ -74,14 +74,26 @@ final class ModelStateEmptySectionLayoutTests: XCTestCase {
     let initialSections = [
       SectionModel(
         itemModels: [],
-        headerModel: HeaderModel(heightMode: .static(height: 45), height: 45),
-        footerModel: FooterModel(heightMode: .static(height: 45), height: 45),
+        headerModel: HeaderModel(
+          heightMode: .static(height: 45),
+          height: 45,
+          pinToVisibleBounds: false),
+        footerModel: FooterModel(
+          heightMode: .static(height: 45),
+          height: 45,
+          pinToVisibleBounds: false),
         backgroundModel: BackgroundModel(),
         metrics: metrics0),
       SectionModel(
         itemModels: [],
-        headerModel: HeaderModel(heightMode: .static(height: 65), height: 65),
-        footerModel: FooterModel(heightMode: .static(height: 65), height: 65),
+        headerModel: HeaderModel(
+          heightMode: .static(height: 65),
+          height: 65,
+          pinToVisibleBounds: false),
+        footerModel: FooterModel(
+          heightMode: .static(height: 65),
+          height: 65,
+          pinToVisibleBounds: false),
         backgroundModel: BackgroundModel(),
         metrics: metrics1),
       ]

--- a/Tests/ModelStateInitiallSetUpTests.swift
+++ b/Tests/ModelStateInitiallSetUpTests.swift
@@ -22,7 +22,7 @@ final class ModelStateInitialSetUpTests: XCTestCase {
   // MARK: Internal
 
   override func setUp() {
-    modelState = ModelState()
+    modelState = ModelState(currentVisibleBoundsProvider: { return .zero })
   }
 
   override func tearDown() {

--- a/Tests/ModelStateUpdateTests.swift
+++ b/Tests/ModelStateUpdateTests.swift
@@ -22,7 +22,7 @@ final class ModelStateUpdateTests: XCTestCase {
   // MARK: Internal
 
   override func setUp() {
-    modelState = ModelState()
+    modelState = ModelState(currentVisibleBoundsProvider: { return .zero })
   }
 
   override func tearDown() {


### PR DESCRIPTION
## Details

This adds support for pinned (sticky) headers and footers. Using a new parameter on `MagazineLayoutHeaderVisibilityMode` and `MagazineLayoutFooterVisibilityMode` (these will be unified in the future, but it's a larger API-breaking change to do that), users can have headers pin to the top of the screen when scrolling down, or have footers pin to the bottom of the screen when scrolling up.

#### Section 0 has a sticky header, section 2 has a sticky footer

![ezgif-2-81799c0b5b10](https://user-images.githubusercontent.com/746571/61166758-e5202300-a4e7-11e9-9aa5-09095cfbdeb4.gif)

#### Example in the search flow of the Airbnb app

![ezgif com-video-to-gif-6](https://user-images.githubusercontent.com/746571/61166788-48aa5080-a4e8-11e9-90a3-1baa662e0f8c.gif)


## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
