### PR TITLE
Fix iOS 13 batch update animations

### DIFF
--- a/Example/MagazineLayoutExample.xcodeproj/project.pbxproj
+++ b/Example/MagazineLayoutExample.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		FCAC642A2208870300973F4C /* Footer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAC64292208870300973F4C /* Footer.swift */; };
 		8F78E959225BD81000CAE309 /* Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F78E958225BD81000CAE309 /* Background.swift */; };
+		FCAC642A2208870300973F4C /* Footer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAC64292208870300973F4C /* Footer.swift */; };
 		FD138CD421B201D0006BFABC /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD138CD321B201D0006BFABC /* Data.swift */; };
 		FD138CD621B20875006BFABC /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD138CD521B20875006BFABC /* Cell.swift */; };
 		FD138CD821B226A7006BFABC /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD138CD721B226A7006BFABC /* Header.swift */; };
@@ -40,8 +40,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FCAC64292208870300973F4C /* Footer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Footer.swift; sourceTree = "<group>"; };
 		8F78E958225BD81000CAE309 /* Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Background.swift; sourceTree = "<group>"; };
+		FCAC64292208870300973F4C /* Footer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Footer.swift; sourceTree = "<group>"; };
 		FD138CD321B201D0006BFABC /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		FD138CD521B20875006BFABC /* Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		FD138CD721B226A7006BFABC /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
@@ -358,7 +358,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5Q5SGQT2R4;
 				INFOPLIST_FILE = MagazineLayoutExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -379,7 +379,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5Q5SGQT2R4;
 				INFOPLIST_FILE = MagazineLayoutExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.5.0'
+  s.version  = '1.5.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -518,6 +518,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -545,6 +546,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -341,6 +341,9 @@ public final class MagazineLayout: UICollectionViewLayout {
   override public func finalizeCollectionViewUpdates() {
     modelState.clearInProgressBatchUpdateState()
 
+    itemLayoutAttributesForInFlightAnimations.removeAll()
+    supplementaryViewLayoutAttributesForInFlightAnimations.removeAll()
+
     super.finalizeCollectionViewUpdates()
   }
 
@@ -481,6 +484,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     {
       let attributes = layoutAttributesForItem(at: itemIndexPath)?.copy() as? UICollectionViewLayoutAttributes
       attributes?.alpha = 0
+      itemLayoutAttributesForInFlightAnimations[itemIndexPath] = attributes
       return attributes
     } else if
       let movedItemID = modelState.idForItemModel(at: itemIndexPath, .afterUpdates),
@@ -511,7 +515,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         withID: movedItemID,
         .afterUpdates)
     {
-      return layoutAttributesForItem(at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      let attributes = layoutAttributesForItem(at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      itemLayoutAttributesForInFlightAnimations[finalIndexPath] = attributes
+      return attributes
     } else {
       return super.layoutAttributesForItem(at: itemIndexPath)
     }
@@ -527,6 +533,7 @@ public final class MagazineLayout: UICollectionViewLayout {
         ofKind: elementKind,
         at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
       attributes?.alpha = 0
+      supplementaryViewLayoutAttributesForInFlightAnimations[elementIndexPath] = attributes
       return attributes
     } else if
       let movedSectionID = modelState.idForSectionModel(
@@ -537,7 +544,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         .beforeUpdates)
     {
       let initialIndexPath = IndexPath(item: 0, section: initialSectionIndex)
-      return previousLayoutAttributesForSupplementaryView(ofKind: elementKind, at: initialIndexPath)
+      return previousLayoutAttributesForSupplementaryView(
+        ofKind: elementKind,
+        at: initialIndexPath)
     } else {
       return super.initialLayoutAttributesForAppearingSupplementaryElement(
         ofKind: elementKind,
@@ -565,9 +574,11 @@ public final class MagazineLayout: UICollectionViewLayout {
         .afterUpdates)
     {
       let finalIndexPath = IndexPath(item: 0, section: finalSectionIndex)
-      return layoutAttributesForSupplementaryView(
+      let attributes = layoutAttributesForSupplementaryView(
         ofKind: elementKind,
         at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
+      supplementaryViewLayoutAttributesForInFlightAnimations[finalIndexPath] = attributes
+      return attributes
     }  else {
       return super.finalLayoutAttributesForDisappearingSupplementaryElement(
         ofKind: elementKind,
@@ -649,19 +660,38 @@ public final class MagazineLayout: UICollectionViewLayout {
       modelState.updateItemHeight(
         toPreferredHeight: preferredAttributes.size.height,
         forItemAt: preferredAttributes.indexPath)
+
+      let layoutAttributesForInFlightAnimation = itemLayoutAttributesForInFlightAnimations[preferredAttributes.indexPath]
+      layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForItem(
+        at: ElementLocation(indexPath: preferredAttributes.indexPath),
+        .afterUpdates).height
+
     case .supplementaryView:
+      let layoutAttributesForInFlightAnimation = supplementaryViewLayoutAttributesForInFlightAnimations[preferredAttributes.indexPath]
+
       switch preferredAttributes.representedElementKind {
       case MagazineLayout.SupplementaryViewKind.sectionHeader?:
         modelState.updateHeaderHeight(
           toPreferredHeight: preferredAttributes.size.height,
           forSectionAtIndex: preferredAttributes.indexPath.section)
+
+        layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForHeader(
+          inSectionAtIndex: preferredAttributes.indexPath.section,
+          .afterUpdates)?.height ?? preferredAttributes.size.height
+
       case MagazineLayout.SupplementaryViewKind.sectionFooter?:
         modelState.updateFooterHeight(
           toPreferredHeight: preferredAttributes.size.height,
           forSectionAtIndex: preferredAttributes.indexPath.section)
+
+        layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForFooter(
+          inSectionAtIndex: preferredAttributes.indexPath.section,
+          .afterUpdates)?.height ?? preferredAttributes.size.height
+
       default:
         break
       }
+
     case .decorationView:
       assertionFailure("`MagazineLayout` does not support decoration views")
     }
@@ -765,6 +795,12 @@ public final class MagazineLayout: UICollectionViewLayout {
   private var headerLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
   private var footerLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
   private var backgroundLayoutAttributes = [ElementLocation: MagazineLayoutCollectionViewLayoutAttributes]()
+
+  // These properties are used to keep the layout attributes copies used for insert/delete
+  // animations up-to-date as items are self-sized. If we don't keep these copies up-to-date, then
+  // animations will start from the estimated height.
+  private var itemLayoutAttributesForInFlightAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
+  private var supplementaryViewLayoutAttributesForInFlightAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
 
   private struct PrepareActions: OptionSet {
     let rawValue: UInt

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -341,8 +341,8 @@ public final class MagazineLayout: UICollectionViewLayout {
   override public func finalizeCollectionViewUpdates() {
     modelState.clearInProgressBatchUpdateState()
 
-    itemLayoutAttributesForInFlightAnimations.removeAll()
-    supplementaryViewLayoutAttributesForInFlightAnimations.removeAll()
+    itemLayoutAttributesForPendingAnimations.removeAll()
+    supplementaryViewLayoutAttributesForPendingAnimations.removeAll()
 
     super.finalizeCollectionViewUpdates()
   }
@@ -484,7 +484,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     {
       let attributes = layoutAttributesForItem(at: itemIndexPath)?.copy() as? UICollectionViewLayoutAttributes
       attributes?.alpha = 0
-      itemLayoutAttributesForInFlightAnimations[itemIndexPath] = attributes
+      itemLayoutAttributesForPendingAnimations[itemIndexPath] = attributes
       return attributes
     } else if
       let movedItemID = modelState.idForItemModel(at: itemIndexPath, .afterUpdates),
@@ -516,7 +516,7 @@ public final class MagazineLayout: UICollectionViewLayout {
         .afterUpdates)
     {
       let attributes = layoutAttributesForItem(at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
-      itemLayoutAttributesForInFlightAnimations[finalIndexPath] = attributes
+      itemLayoutAttributesForPendingAnimations[finalIndexPath] = attributes
       return attributes
     } else {
       return super.layoutAttributesForItem(at: itemIndexPath)
@@ -533,7 +533,7 @@ public final class MagazineLayout: UICollectionViewLayout {
         ofKind: elementKind,
         at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
       attributes?.alpha = 0
-      supplementaryViewLayoutAttributesForInFlightAnimations[elementIndexPath] = attributes
+      supplementaryViewLayoutAttributesForPendingAnimations[elementIndexPath] = attributes
       return attributes
     } else if
       let movedSectionID = modelState.idForSectionModel(
@@ -577,7 +577,7 @@ public final class MagazineLayout: UICollectionViewLayout {
       let attributes = layoutAttributesForSupplementaryView(
         ofKind: elementKind,
         at: finalIndexPath)?.copy() as? UICollectionViewLayoutAttributes
-      supplementaryViewLayoutAttributesForInFlightAnimations[finalIndexPath] = attributes
+      supplementaryViewLayoutAttributesForPendingAnimations[finalIndexPath] = attributes
       return attributes
     }  else {
       return super.finalLayoutAttributesForDisappearingSupplementaryElement(
@@ -661,13 +661,13 @@ public final class MagazineLayout: UICollectionViewLayout {
         toPreferredHeight: preferredAttributes.size.height,
         forItemAt: preferredAttributes.indexPath)
 
-      let layoutAttributesForInFlightAnimation = itemLayoutAttributesForInFlightAnimations[preferredAttributes.indexPath]
-      layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForItem(
+      let layoutAttributesForPendingAnimation = itemLayoutAttributesForPendingAnimations[preferredAttributes.indexPath]
+      layoutAttributesForPendingAnimation?.frame.size.height = modelState.frameForItem(
         at: ElementLocation(indexPath: preferredAttributes.indexPath),
         .afterUpdates).height
 
     case .supplementaryView:
-      let layoutAttributesForInFlightAnimation = supplementaryViewLayoutAttributesForInFlightAnimations[preferredAttributes.indexPath]
+      let layoutAttributesForPendingAnimation = supplementaryViewLayoutAttributesForPendingAnimations[preferredAttributes.indexPath]
 
       switch preferredAttributes.representedElementKind {
       case MagazineLayout.SupplementaryViewKind.sectionHeader?:
@@ -675,7 +675,7 @@ public final class MagazineLayout: UICollectionViewLayout {
           toPreferredHeight: preferredAttributes.size.height,
           forSectionAtIndex: preferredAttributes.indexPath.section)
 
-        layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForHeader(
+        layoutAttributesForPendingAnimation?.frame.size.height = modelState.frameForHeader(
           inSectionAtIndex: preferredAttributes.indexPath.section,
           .afterUpdates)?.height ?? preferredAttributes.size.height
 
@@ -684,7 +684,7 @@ public final class MagazineLayout: UICollectionViewLayout {
           toPreferredHeight: preferredAttributes.size.height,
           forSectionAtIndex: preferredAttributes.indexPath.section)
 
-        layoutAttributesForInFlightAnimation?.frame.size.height = modelState.frameForFooter(
+        layoutAttributesForPendingAnimation?.frame.size.height = modelState.frameForFooter(
           inSectionAtIndex: preferredAttributes.indexPath.section,
           .afterUpdates)?.height ?? preferredAttributes.size.height
 
@@ -799,8 +799,8 @@ public final class MagazineLayout: UICollectionViewLayout {
   // These properties are used to keep the layout attributes copies used for insert/delete
   // animations up-to-date as items are self-sized. If we don't keep these copies up-to-date, then
   // animations will start from the estimated height.
-  private var itemLayoutAttributesForInFlightAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
-  private var supplementaryViewLayoutAttributesForInFlightAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
+  private var itemLayoutAttributesForPendingAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
+  private var supplementaryViewLayoutAttributesForPendingAnimations = [IndexPath: UICollectionViewLayoutAttributes]()
 
   private struct PrepareActions: OptionSet {
     let rawValue: UInt


### PR DESCRIPTION
## Details

This fixes an iOS 13 issue where copies of layout attributes returned from `itemLayoutAttributesForInFlightAnimations` and `finalLayoutAttributesForDisappearingItem` will cause the collection view to start animations from an estimated height, rather than the final height. On iOS 12 and below, this is not an issue. On iOS 13, the copies returned from these functions must be kept up-to-date with the latest size information ask items self-size.

| Before | After |
| ---- | ---- |
| ![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/746571/65461468-d4096180-de08-11e9-8342-114009e1ae63.gif) | ![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/746571/65461382-9a385b00-de08-11e9-8a7f-fbc4ad44cef0.gif)  | 

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

This solves insert animations looking wrong on iOS 13.

## How Has This Been Tested

Tested with various insert / delete scenarios in the simulator. Unfortunately, this code is in the UIKit part of `MagazineLayout`, so it's not currently testable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.