### PR TITLE
fix(TestingSupport): Fix warning in TestingSupport.swift

### DIFF
--- a/Tests/TestingSupport.swift
+++ b/Tests/TestingSupport.swift
@@ -207,6 +207,10 @@ extension Array where Element == CGRect {
 
 extension CGRect: Hashable {
 
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(hashValue)
+  }
+
   public var hashValue: Int {
     return NSStringFromCGRect(self).hashValue
   }

--- a/Tests/TestingSupport.swift
+++ b/Tests/TestingSupport.swift
@@ -208,11 +208,26 @@ extension Array where Element == CGRect {
 extension CGRect: Hashable {
 
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(hashValue)
+    hasher.combine(size)
+    hasher.combine(origin)
   }
 
-  public var hashValue: Int {
-    return NSStringFromCGRect(self).hashValue
+}
+
+extension CGSize: Hashable {
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(height)
+    hasher.combine(width)
+  }
+
+}
+
+extension CGPoint: Hashable {
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(x)
+    hasher.combine(y)
   }
 
 }


### PR DESCRIPTION
## Details

This pull-request contains improvements about avoid warnings in CGRect+Hashable extension.
You can check out the cause of the warning in this link -> [Apple Reference](https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md#source-compatibility)

## Related Issue

## Motivation and Context

This solves warning in `CGRect+Hashable` extension in TestingSupport.swift.

![Screen Shot 2019-11-11 at 08 39 57](https://user-images.githubusercontent.com/19268363/68735124-baf18580-05ed-11ea-97c7-3cc6fb4610a5.png)

## How Has This Been Tested

Tested with Example project via simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
