### PR TITLE
Adding fix for sticky headers when the collection view has a refresh control

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -362,7 +362,15 @@ public final class MagazineLayout: UICollectionViewLayout {
         continue
       }
 
-      layoutAttributes.frame = headerFrame
+      var updatedHeaderFrame = headerFrame
+
+      if let refreshControl = currentCollectionView.refreshControl,
+        currentCollectionView.isDragging && refreshControl.isRefreshing && currentCollectionView.isDecelerating
+      {
+        updatedHeaderFrame.origin.y -= refreshControl.bounds.size.height
+      }
+
+      layoutAttributes.frame = updatedHeaderFrame
       layoutAttributesInRect.append(layoutAttributes)
 
     }

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -365,9 +365,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       var updatedHeaderFrame = headerFrame
 
       if let refreshControl = currentCollectionView.refreshControl,
-        currentCollectionView.isDragging && refreshControl.isRefreshing && currentCollectionView.isDecelerating
+        refreshControl.isRefreshing && currentVisibleBounds.origin.y > refreshControl.bounds.height
       {
-        updatedHeaderFrame.origin.y -= refreshControl.bounds.size.height
+        updatedHeaderFrame.origin.y -= refreshControl.bounds.height
       }
 
       layoutAttributes.frame = updatedHeaderFrame


### PR DESCRIPTION
## Details

 While the collectionView is refreshing, if someone were to scroll down the sticky header's positioning is not adjusted properly. This fix updates the header frame, accounting for the refresh control height when the user is scrolling down. 

## Related Issue

This is related to issue #61.

## Motivation and Context

This change is required if the user wants to add a refresh control to the collection view and use pinned headers as well

## How Has This Been Tested

#### Before
<img src=https://user-images.githubusercontent.com/49168598/69503386-33f2b600-0ee7-11ea-96f9-74d377c71182.gif width="200">

#### After
<img src=https://user-images.githubusercontent.com/49168598/69502874-f3dd0480-0ee1-11ea-9e08-74d9767f2d06.gif width="200">


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
