### PR TITLE
Fix: Crash on empty section layout when footer visibility is toggled

### DIFF
--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -438,10 +438,6 @@ extension ViewController: UICollectionViewDelegateMagazineLayout {
     visibilityModeForFooterInSectionAtIndex index: Int)
     -> MagazineLayoutFooterVisibilityMode
   {
-    if dataSource.numberOfItemsInSection(withIndex: index) == 0 {
-      return .hidden
-    }
-
     return dataSource.sectionInfos[index].footerInfo.visibilityMode
   }
 

--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -403,13 +403,8 @@ extension ViewController: UICollectionViewDelegate {
 
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     collectionView.performBatchUpdates({
-      if dataSource.numberOfItemsInSection(withIndex: indexPath.section) > 1 {
-        dataSource.removeItem(atItemIndex: indexPath.item, inSectionAtIndex: indexPath.section)
-        collectionView.deleteItems(at: [indexPath])
-      } else {
-        dataSource.removeSection(atSectionIndex: indexPath.section)
-        collectionView.deleteSections(IndexSet(integer: indexPath.section))
-      }
+      dataSource.removeItem(atItemIndex: indexPath.item, inSectionAtIndex: indexPath.section)
+      collectionView.deleteItems(at: [indexPath])
     }, completion: nil)
   }
 
@@ -443,6 +438,10 @@ extension ViewController: UICollectionViewDelegateMagazineLayout {
     visibilityModeForFooterInSectionAtIndex index: Int)
     -> MagazineLayoutFooterVisibilityMode
   {
+    if dataSource.numberOfItemsInSection(withIndex: index) == 0 {
+      return .hidden
+    }
+
     return dataSource.sectionInfos[index].footerInfo.visibilityMode
   }
 

--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -403,8 +403,13 @@ extension ViewController: UICollectionViewDelegate {
 
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     collectionView.performBatchUpdates({
-      dataSource.removeItem(atItemIndex: indexPath.item, inSectionAtIndex: indexPath.section)
-      collectionView.deleteItems(at: [indexPath])
+      if dataSource.numberOfItemsInSection(withIndex: indexPath.section) > 1 {
+        dataSource.removeItem(atItemIndex: indexPath.item, inSectionAtIndex: indexPath.section)
+        collectionView.deleteItems(at: [indexPath])
+      } else {
+        dataSource.removeSection(atSectionIndex: indexPath.section)
+        collectionView.deleteSections(IndexSet(integer: indexPath.section))
+      }
     }, completion: nil)
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -558,7 +558,10 @@ public final class MagazineLayout: UICollectionViewLayout {
     at elementIndexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
-    if elementIndexPath.isEmpty {
+   // If a supplementary view's visibility changes to `.hidden` due to a data source change, this
+    // function will get invoked with an `elementIndexPath` that crashes when its `section` is
+    // accessed.
+    guard !elementIndexPath.isEmpty else {
       return super.initialLayoutAttributesForAppearingSupplementaryElement(
         ofKind: elementKind,
         at: elementIndexPath)

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -558,6 +558,12 @@ public final class MagazineLayout: UICollectionViewLayout {
     at elementIndexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
+    if elementIndexPath.isEmpty {
+      return super.initialLayoutAttributesForAppearingSupplementaryElement(
+        ofKind: elementKind,
+        at: elementIndexPath)
+    }
+
     if modelState.sectionIndicesToInsert.contains(elementIndexPath.section) {
       let attributes = layoutAttributesForSupplementaryView(
         ofKind: elementKind,


### PR DESCRIPTION
## Details

A crash occurs during layout when a section is updated to: 
1. be empty
2. hide the footer

Under these conditions, `initialLayoutAttributesForAppearingSupplementaryElement(ofKind elementKind: String, at elementIndexPath: IndexPath)`
is called with an **empty** IndexPath. This results in a crash when `elementIndexPath.section` is accessed. 

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

Our project has a notion of a `collapsed` section, which is essentially an empty section. 
`Collapsed` sections do not show a footer view, but the expanded section may have a footer.

## How Has This Been Tested

I have modified the example project to reproduce the issue (see second commit on my PR). 
To test, I removed all of the items from a section that had a footer.
I observed that:
*without the fix*, the modified example crashes
*with the fix*, the modified example does not crash

I took at look at the test suite to see if I could add coverage for this test case, but I'm not sure what the your preferred strategy for testing this code path would be. The logic lives within the `MagazineLayout` class, which is not currently under test, as far as I can tell. 

**Note**: I'm not sure that the changes to example app are appropriate to bring back, but I wanted to be able to show you what was up. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. ( I think so?) 
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
