### PR TITLE
Bk/fix pinned headers refresh control

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.5.3'
+  s.version  = '1.5.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -239,7 +239,7 @@ final class ModelState {
       withElementLocationsForFlattenedIndices: headerLocationsForFlattenedIndices,
       andFramesProvidedBy: { headerLocation -> CGRect in
         guard
-          let footerFrame = frameForHeader(
+          let headerFrame = frameForHeader(
             inSectionAtIndex: headerLocation.sectionIndex,
             .afterUpdates) else
         {
@@ -247,7 +247,7 @@ final class ModelState {
           return .zero
         }
 
-        return footerFrame
+        return headerFrame
       })
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -820,11 +820,21 @@ public final class MagazineLayout: UICollectionViewLayout {
       contentInset = currentCollectionView.contentInset
     }
 
+    let refreshControlHeight: CGFloat
+    if
+      let refreshControl = currentCollectionView.refreshControl,
+      refreshControl.isRefreshing
+    {
+      refreshControlHeight = refreshControl.bounds.height
+    } else {
+      refreshControlHeight = 0
+    }
+
     return CGRect(
       x: currentCollectionView.bounds.minX + contentInset.left,
-      y: currentCollectionView.bounds.minY + contentInset.top,
+      y: currentCollectionView.bounds.minY + contentInset.top - refreshControlHeight,
       width: currentCollectionView.bounds.width - contentInset.left - contentInset.right,
-      height: currentCollectionView.bounds.height - contentInset.top - contentInset.bottom)
+      height: currentCollectionView.bounds.height - contentInset.top - contentInset.bottom + refreshControlHeight)
   }
 
   private var delegateMagazineLayout: UICollectionViewDelegateMagazineLayout? {

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -812,6 +812,8 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
   private var prepareActions: PrepareActions = []
 
+  // Used to provide the model state with the current visible bounds for the sole purpose of
+  // supporting pinned headers and footers.
   private var currentVisibleBounds: CGRect {
     let contentInset: UIEdgeInsets
     if #available(iOS 11.0, *) {


### PR DESCRIPTION
## Details

This is an alternate solution to https://github.com/airbnb/MagazineLayout/pull/62, which is a fix for https://github.com/airbnb/MagazineLayout/issues/61

From the original PR:

> While the collectionView is refreshing, if someone were to scroll down the sticky header's positioning is not adjusted properly. This fix updates the header frame, accounting for the refresh control height when the user is scrolling down.

## Related Issue

https://github.com/airbnb/MagazineLayout/issues/61

## Motivation and Context

If we don't introduce this code, then pinned headers with a refresh control look incorrect.

| Before | After |
| ---- | ---- |
| ![69503386-33f2b600-0ee7-11ea-96f9-74d377c71182](https://user-images.githubusercontent.com/746571/71287813-51287200-2337-11ea-8c51-c01f9703d3f7.gif) | ![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/746571/71287831-5a194380-2337-11ea-8e64-13ae49e7fa0b.gif) | 

## How Has This Been Tested

Tested in sample app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
