### PR TITLE
Fix overlapping items after off-screen updates

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.5.4'
+  s.version  = '1.5.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.3;
+				MARKETING_VERSION = 1.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -548,7 +548,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.3;
+				MARKETING_VERSION = 1.5.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details

This PR fixes an issue that causes off-screen batch updates to sometimes cause visual defects in the form of temporary overlapping items. It's probably a `UICollectionView` bug, but thankfully, there's a way for `MagazineLayout` to work around it. Here's the technical description straight from the in-code documentation:

This  prevents an issue that causes overlapping / misplaced elements after an
off-screen batch update occurs. The root cause of this issue is that `UICollectionView`
expects `layoutAttributesForElementsInRect:` to return post-batch-update layout attributes
immediately after an update is sent to the collection view via the insert/delete/reload/move
functions. Unfortunately, this is impossible - when batch updates occur, `invalidateLayout:`
is invoked immediately with a context that has `invalidateDataSourceCounts` set to `true`.
At this time, `MagazineLayout` has no way of knowing the details of this data source count
change (where the insert/delete/move took place). `MagazineLayout` only gets this additional
information once `prepareForCollectionViewUpdates:` is invoked. At that time, we're able to
update our layout's source of truth, the `ModelState`, which allows us to resolve the
post-batch-update layout and return post-batch-update layout attributes from this function.
Between the time that `invalidateLayout:` is invoked with `invalidateDataSourceCounts` set to
`true`, and when `prepareForCollectionViewUpdates:` is invoked with details of the updates,
`layoutAttributesForElementsInRect:` is invoked with the expectation that we already have a
fully resolved layout. If we return incorrect layout attributes at that time, then we'll have
overlapping elements / visual defects. To prevent this, we can return `nil` in this
 situation, which works around the bug.
`UICollectionViewCompositionalLayout`, in classic UIKit fashion, avoids this bug / feature by
implementing the private function
`_prepareForCollectionViewUpdates:withDataSourceTranslator:`, which provides the layout with
details about the updates to the collection view before `layoutAttributesForElementsInRect:`
is invoked, enabling them to resolve their layout in time.

| Before | After |
| ---- | ---- |
| ![ezgif-6-ee03da57d312](https://user-images.githubusercontent.com/746571/74905753-e1009180-5363-11ea-9cfc-6895879a95bf.gif) | ![ezgif com-video-to-gif-6](https://user-images.githubusercontent.com/746571/74905762-e65ddc00-5363-11ea-98eb-50c3308fdedf.gif) |

| Before | After |
| ---- | ---- |
| ![ezgif com-video-to-gif-8](https://user-images.githubusercontent.com/746571/74905900-48b6dc80-5364-11ea-9d60-51eb5d480c35.gif) | ![ezgif com-video-to-gif-9](https://user-images.githubusercontent.com/746571/74905907-4f455400-5364-11ea-9829-6e93e972e2fd.gif) |

## Related Issue

N/A

## Motivation and Context

This works around an old issue that's affected `MagazineLayout` since day one. Also, I love a good `UICollectionView` bug.

## How Has This Been Tested
- Tested in sample project
- Tested in Airbnb app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
