### PR TITLE
Add customizable insert/delete animations

### DIFF
--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -494,4 +494,15 @@ extension ViewController: UICollectionViewDelegateMagazineLayout {
     return UIEdgeInsets(top: 24, left: 4, bottom: 24, right: 4)
   }
 
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedItemAt indexPath: IndexPath,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // Fade and drop out
+    finalLayoutAttributes.alpha = 0
+    finalLayoutAttributes.transform = .init(scaleX: 0.2, y: 0.2)
+  }
+
 }

--- a/Example/MagazineLayoutExample/ViewController.swift
+++ b/Example/MagazineLayoutExample/ViewController.swift
@@ -81,11 +81,12 @@ final class ViewController: UIViewController {
   private var lastItemCreationPanelViewState: ItemCreationPanelViewState?
 
   private func removeAllData() {
-    for sectionIndex in (0..<dataSource.numberOfSections).reversed() {
-      dataSource.removeSection(atSectionIndex: sectionIndex)
-    }
-
-    collectionView.reloadData()
+    collectionView.performBatchUpdates({
+      for sectionIndex in (0..<dataSource.numberOfSections).reversed() {
+        dataSource.removeSection(atSectionIndex: sectionIndex)
+        collectionView.deleteSections(IndexSet(arrayLiteral: sectionIndex))
+      }
+    }, completion: nil)
   }
 
   private func loadDefaultData() {
@@ -307,11 +308,13 @@ final class ViewController: UIViewController {
       backgroundInfo: BackgroundInfo(visibilityMode: .hidden)
     )
 
-    dataSource.insert(section0, atSectionIndex: 0)
-    dataSource.insert(section1, atSectionIndex: 1)
-    dataSource.insert(section2, atSectionIndex: 2)
+    collectionView.performBatchUpdates({
+      dataSource.insert(section0, atSectionIndex: 0)
+      dataSource.insert(section1, atSectionIndex: 1)
+      dataSource.insert(section2, atSectionIndex: 2)
 
-    collectionView.reloadData()
+      collectionView.insertSections(IndexSet(arrayLiteral: 0, 1, 2))
+    }, completion: nil)
   }
 
   @objc

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.5.5'
+  s.version  = '1.6.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -548,7 +548,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -513,7 +513,13 @@ public final class MagazineLayout: UICollectionViewLayout {
       modelState.sectionIndicesToInsert.contains(itemIndexPath.section)
     {
       let attributes = layoutAttributesForItem(at: itemIndexPath)?.copy() as? UICollectionViewLayoutAttributes
-      attributes?.alpha = 0
+      attributes.map {
+        delegateMagazineLayout?.collectionView(
+          currentCollectionView,
+          layout: self,
+          initialLayoutAttributesForInsertedItemAt: itemIndexPath,
+          byModifying: $0)
+      }
       itemLayoutAttributesForPendingAnimations[itemIndexPath] = attributes
       return attributes
     } else if
@@ -537,7 +543,13 @@ public final class MagazineLayout: UICollectionViewLayout {
       modelState.sectionIndicesToDelete.contains(itemIndexPath.section)
     {
       let attributes = previousLayoutAttributesForItem(at: itemIndexPath)
-      attributes?.alpha = 0
+      attributes.map {
+        delegateMagazineLayout?.collectionView(
+          currentCollectionView,
+          layout: self,
+          finalLayoutAttributesForRemovedItemAt: itemIndexPath,
+          byModifying: $0)
+      }
       return attributes
     } else if
       let movedItemID = modelState.idForItemModel(at: itemIndexPath, .beforeUpdates),
@@ -571,7 +583,12 @@ public final class MagazineLayout: UICollectionViewLayout {
       let attributes = layoutAttributesForSupplementaryView(
         ofKind: elementKind,
         at: elementIndexPath)?.copy() as? UICollectionViewLayoutAttributes
-      attributes?.alpha = 0
+      attributes.map {
+        modifySupplementaryViewLayoutAttributesForInsertAnimation(
+          $0,
+          ofKind: elementKind,
+          at: elementIndexPath)
+      }
       supplementaryViewLayoutAttributesForPendingAnimations[elementIndexPath] = attributes
       return attributes
     } else if
@@ -602,7 +619,12 @@ public final class MagazineLayout: UICollectionViewLayout {
       let attributes = previousLayoutAttributesForSupplementaryView(
         ofKind: elementKind,
         at: elementIndexPath)
-      attributes?.alpha = 0
+      attributes.map {
+        modifySupplementaryViewLayoutAttributesForDeleteAnimation(
+          $0,
+          ofKind: elementKind,
+          at: elementIndexPath)
+      }
       return attributes
     } else if
       let movedSectionID = modelState.idForSectionModel(
@@ -1143,6 +1165,64 @@ public final class MagazineLayout: UICollectionViewLayout {
     }
     
     return layoutAttributes
+  }
+
+  private func modifySupplementaryViewLayoutAttributesForInsertAnimation(
+    _ attributes: UICollectionViewLayoutAttributes,
+    ofKind elementKind: String,
+    at indexPath: IndexPath)
+  {
+    switch elementKind {
+    case MagazineLayout.SupplementaryViewKind.sectionHeader:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        initialLayoutAttributesForInsertedHeaderInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    case MagazineLayout.SupplementaryViewKind.sectionFooter:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        initialLayoutAttributesForInsertedFooterInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    case MagazineLayout.SupplementaryViewKind.sectionBackground:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        initialLayoutAttributesForInsertedBackgroundInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    default:
+      assertionFailure("\(elementKind) is not a valid supplementary view element kind.")
+    }
+  }
+
+  private func modifySupplementaryViewLayoutAttributesForDeleteAnimation(
+    _ attributes: UICollectionViewLayoutAttributes,
+    ofKind elementKind: String,
+    at indexPath: IndexPath)
+  {
+    switch elementKind {
+    case MagazineLayout.SupplementaryViewKind.sectionHeader:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        finalLayoutAttributesForRemovedHeaderInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    case MagazineLayout.SupplementaryViewKind.sectionFooter:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        finalLayoutAttributesForRemovedFooterInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    case MagazineLayout.SupplementaryViewKind.sectionBackground:
+      delegateMagazineLayout?.collectionView(
+        currentCollectionView,
+        layout: self,
+        finalLayoutAttributesForRemovedBackgroundInSectionAtIndex: indexPath.section,
+        byModifying: attributes)
+    default:
+      assertionFailure("\(elementKind) is not a valid supplementary view element kind.")
+    }
   }
 
 }

--- a/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
+++ b/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
@@ -15,6 +15,8 @@
 
 import UIKit
 
+// MARK: - UICollectionViewDelegateMagazineLayout
+
 public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate {
 
   ///   Asks the delegate for the size mode of the specified item.
@@ -134,5 +136,248 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     layout collectionViewLayout: UICollectionViewLayout,
     insetsForItemsInSectionAtIndex index: Int)
     -> UIEdgeInsets
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the initial visual state of an item being inserted via
+  ///   `UICollectionView.insertItems(at:)`.
+  ///
+  ///   The `initialLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the item will be inserted with no animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - indexPath: The index path of the item.
+  ///      - initialLayoutAttributes: The unmodified layout attributes representing the final visual state of the inserted
+  ///      item. Modify properties on this instance to create an item insert animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedItemAt indexPath: IndexPath,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the initial visual state of a header being inserted
+  ///   via `UICollectionView.insertSections(_:)`.
+  ///
+  ///   The `initialLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the header will be inserted with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the header.
+  ///      - initialLayoutAttributes: The unmodified layout attributes representing the final visual state of the inserted
+  ///      header. Modify properties on this instance to create a header insert animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedHeaderInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the initial visual state of a footer being inserted
+  ///   via `UICollectionView.insertSections(_:)`.
+  ///
+  ///   The `initialLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the footer will be inserted with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the footer.
+  ///      - initialLayoutAttributes: The unmodified layout attributes representing the final visual state of the inserted
+  ///      footer. Modify properties on this instance to create a footer insert animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedFooterInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the initial visual state of a background being
+  ///   inserted via `UICollectionView.insertSections(_:)`.
+  ///
+  ///   The `initialLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the background will be inserted with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the background.
+  ///      - initialLayoutAttributes: The unmodified layout attributes representing the final visual state of the inserted
+  ///      background. Modify properties on this instance to create a background insert animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedBackgroundInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the final visual state of an item being removed via
+  ///   `UICollectionView.deleteItems(at:)`.
+  ///
+  ///   The `finalLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the item will be removed with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - indexPath: The index path of the item.
+  ///      - finalLayoutAttributes: The unmodified layout attributes representing the final visual state of the removed item.
+  ///      Modify properties on this instance to create an item delete animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedItemAt indexPath: IndexPath,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the final visual state of a header being removed
+  ///   via `UICollectionView.deleteSections(_:)`.
+  ///
+  ///   The `finalLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the header will be removed with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the header.
+  ///      - finalLayoutAttributes: The unmodified layout attributes representing the final visual state of the removed
+  ///      header. Modify properties on this instance to create a header delete animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedHeaderInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the final visual state of a footer being removed
+  ///   via `UICollectionView.deleteSections(_:)`.
+  ///
+  ///   The `finalLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the footer will be removed with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the footer.
+  ///      - finalLayoutAttributes: The unmodified layout attributes representing the final visual state of the removed
+  ///      footer. Modify properties on this instance to create a footer delete animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedFooterInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+
+  ///   Asks the delegate to modify a layout attributes instance so that it represents the final visual state of a background being
+  ///   removed via `UICollectionView.deleteSections(_:)`.
+  ///
+  ///   The `finalLayoutAttributes` instance is a reference type, and therefore can be modified directly. If the provided
+  ///   layout attributes instance is not changed in the implementation of this function, then the background will be removed with no
+  ///   animation.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - index: The index of the section containing the background.
+  ///      - finalLayoutAttributes: The unmodified layout attributes representing the final visual state of the removed
+  ///      background. Modify properties on this instance to create a background delete animation.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedBackgroundInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+
+}
+
+// MARK: Default Insert Animations
+
+public extension UICollectionViewDelegateMagazineLayout {
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedItemAt indexPath: IndexPath,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-in.
+    initialLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedHeaderInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-in.
+    initialLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedFooterInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-in.
+    initialLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    initialLayoutAttributesForInsertedBackgroundInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-in.
+    initialLayoutAttributes.alpha = 0
+  }
+
+}
+
+// MARK: Default Delete Animations
+
+public extension UICollectionViewDelegateMagazineLayout {
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedItemAt indexPath: IndexPath,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-out.
+    finalLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedHeaderInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-out.
+    finalLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedFooterInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-out.
+    finalLayoutAttributes.alpha = 0
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    finalLayoutAttributesForRemovedBackgroundInSectionAtIndex index: Int,
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default insert animation is a simple fade-out.
+    finalLayoutAttributes.alpha = 0
+  }
 
 }

--- a/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
+++ b/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
@@ -300,8 +300,7 @@ public extension UICollectionViewDelegateMagazineLayout {
     initialLayoutAttributesForInsertedItemAt indexPath: IndexPath,
     byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-in.
-    initialLayoutAttributes.alpha = 0
+    defaultInsertAnimation(byModifying: initialLayoutAttributes)
   }
 
   func collectionView(
@@ -310,8 +309,7 @@ public extension UICollectionViewDelegateMagazineLayout {
     initialLayoutAttributesForInsertedHeaderInSectionAtIndex index: Int,
     byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-in.
-    initialLayoutAttributes.alpha = 0
+    defaultInsertAnimation(byModifying: initialLayoutAttributes)
   }
 
   func collectionView(
@@ -320,14 +318,19 @@ public extension UICollectionViewDelegateMagazineLayout {
     initialLayoutAttributesForInsertedFooterInSectionAtIndex index: Int,
     byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-in.
-    initialLayoutAttributes.alpha = 0
+    defaultInsertAnimation(byModifying: initialLayoutAttributes)
   }
 
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
     initialLayoutAttributesForInsertedBackgroundInSectionAtIndex index: Int,
+    byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    defaultInsertAnimation(byModifying: initialLayoutAttributes)
+  }
+
+  private func defaultInsertAnimation(
     byModifying initialLayoutAttributes: UICollectionViewLayoutAttributes)
   {
     // The default insert animation is a simple fade-in.
@@ -346,8 +349,7 @@ public extension UICollectionViewDelegateMagazineLayout {
     finalLayoutAttributesForRemovedItemAt indexPath: IndexPath,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-out.
-    finalLayoutAttributes.alpha = 0
+    defaultDeleteAnimation(byModifying: finalLayoutAttributes)
   }
 
   func collectionView(
@@ -356,8 +358,7 @@ public extension UICollectionViewDelegateMagazineLayout {
     finalLayoutAttributesForRemovedHeaderInSectionAtIndex index: Int,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-out.
-    finalLayoutAttributes.alpha = 0
+    defaultDeleteAnimation(byModifying: finalLayoutAttributes)
   }
 
   func collectionView(
@@ -366,8 +367,7 @@ public extension UICollectionViewDelegateMagazineLayout {
     finalLayoutAttributesForRemovedFooterInSectionAtIndex index: Int,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-out.
-    finalLayoutAttributes.alpha = 0
+    defaultDeleteAnimation(byModifying: finalLayoutAttributes)
   }
 
   func collectionView(
@@ -376,7 +376,13 @@ public extension UICollectionViewDelegateMagazineLayout {
     finalLayoutAttributesForRemovedBackgroundInSectionAtIndex index: Int,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
   {
-    // The default insert animation is a simple fade-out.
+    defaultDeleteAnimation(byModifying: finalLayoutAttributes)
+  }
+
+  private func defaultDeleteAnimation(
+    byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
+  {
+    // The default delete animation is a simple fade-out.
     finalLayoutAttributes.alpha = 0
   }
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection view layout capable of laying out views in vertically scrolling gri
 - Hiding or showing headers and footers on a per-section basis
 - Pinned (sticky) headers and footers
 - Section backgrounds that can be hidden / visible on a per-section basis
+- Customizable insert and delete animations for items and supplementary views
 
 Other features:
 - Specifying horizontal item spacing on a per-section basis


### PR DESCRIPTION
## Details
This PR adds the ability to customize the animation used for newly inserted or deleted elements (items, section headers, section footers, and section backgrounds). The existing behavior was baked into `MagazineLayout`, and could not be customized. With the introduction of some new delegate functions, developers now have the opportunity to mutate layout attributes for inserted and deleted items.

By using default implementations for these new delegate functions, we're able to introduce this new functionality without changing existing animation behavior (a basic alpha fade for both inserts and deletes). This also enables us to introduce this new functionality without requiring any new API adoption.

Known issues:
- Supplementary views don't animate in correctly (they appear immediately). This is potentially a collection view bug, or it might be something we can work around in a future patch. I need to compare with compositional layout to see if this is something we can fix.
- Animations only occur if using `performBatchUpdates`. If a developer uses `reloadData`, the collection view doesn't bother do to any animations. This is expected behavior and will not be worked around or fixed.

Here's an example of customized delete animation:
![ezgif com-video-to-gif-10](https://user-images.githubusercontent.com/746571/79618296-831bcc00-80be-11ea-9d6c-f41ea62fc022.gif)

## Related Issue

N/A

## Motivation and Context

Currently, there is no way to customize insert / delete animations. Apps that want custom insert animations on page load, for example, need to be able to customize these animations.

## How Has This Been Tested

Tested in the iOS simulator using custom insert and delete animations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
