### PR TITLE
Fix empty index path crash

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.0'
+  s.version  = '1.6.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -548,7 +548,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/LayoutCore/Types/ElementLocation.swift
+++ b/MagazineLayout/LayoutCore/Types/ElementLocation.swift
@@ -30,8 +30,16 @@ struct ElementLocation: Hashable {
   }
 
   init(indexPath: IndexPath) {
-    elementIndex = indexPath.item
-    sectionIndex = indexPath.section
+    if indexPath.count == 2 {
+      elementIndex = indexPath.item
+      sectionIndex = indexPath.section
+    } else {
+      // `UICollectionViewFlowLayout` is able to work with empty index paths (`IndexPath()`). Per
+      // the `IndexPath` documntation, an index path that uses `section` or `item` must have exactly
+      // 2 elements. If not, we default to {0, 0} to prevent crashes.
+      elementIndex = 0
+      sectionIndex = 0
+    }
   }
 
   // MARK: Internal

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -445,13 +445,14 @@ public final class MagazineLayout: UICollectionViewLayout {
     let layoutAttributes = itemLayoutAttributes[itemLocation]
 
     guard
-      indexPath.section < modelState.numberOfSections(.afterUpdates),
-      indexPath.item < modelState.numberOfItems(inSectionAtIndex: indexPath.section, .afterUpdates) else
+      itemLocation.sectionIndex < modelState.numberOfSections(.afterUpdates),
+      itemLocation.elementIndex < modelState.numberOfItems(inSectionAtIndex: itemLocation.sectionIndex, .afterUpdates)
+    else
     {
       // On iOS 9, `layoutAttributesForItem(at:)` can be invoked for an index path of a new item
       // before the layout is notified of this new item (through either `prepare` or
       // `prepare(forCollectionViewUpdates:)`). This seems to be fixed in iOS 10 and higher.
-      assertionFailure("`{\(indexPath.section), \(indexPath.item)}` is out of bounds of the section models / item models array.")
+      assertionFailure("`{\(itemLocation.sectionIndex), \(itemLocation.elementIndex)}` is out of bounds of the section models / item models array.")
 
       // Returning `nil` rather than default/frameless layout attributes causes internal exceptions
       // within `UICollecionView`, which is why we don't return `nil` here.


### PR DESCRIPTION
## Details

This fixes #76 - a bug where `MagazineLayout` was assuming that it would only receive "valid" index paths when requesting layout attributes. The crash would occur if a developer passed `IndexPath()` into `layoutAttributesForItemAt`. Flow layout avoids this crash by defaulting to `IndexPath(item: 0, section: 0)`.

Part of me feels like this is just flow layout working around some weird behavior / maybe trying to mirror a workaround table view had from the beginning. The documentation for IndexPath looks like this:

```swift
extension IndexPath {

    /// Initialize for use with `UITableView` or `UICollectionView`.
    public init(row: Int, section: Int)

    /// Initialize for use with `UITableView` or `UICollectionView`.
    public init(item: Int, section: Int)

    /// The section of this index path, when used with `UITableView`.
    ///
    /// - precondition: The index path must have exactly two elements.
    public var section: Int

    /// The row of this index path, when used with `UITableView`.
    ///
    /// - precondition: The index path must have exactly two elements.
    public var row: Int

    /// The item of this index path, when used with `UICollectionView`.
    ///
    /// - precondition: The index path must have exactly two elements.
    public var item: Int
}
```

It specifically calls out that you should use the `init(item: Int, section: Int)` initializer when using `UICollectionView`. To me, this makes it seem like using `IndexPath()` is wrong / a programmer error.

====

Why does collection view / table view even use index paths? Seems like the wrong abstraction to me. `IndexPath`s allow indexing into arbitrarily deep tree structures, which seems completely overboard for a UI component that only has 2 layers (section and item).

Fun reminder than initializing `IndexPath`s is 35x slower than initializing a simple `ElementLocation` struct. See https://github.com/airbnb/MagazineLayout/blob/master/MagazineLayout/LayoutCore/Types/ElementLocation.swift#L23

## Related Issue

#76

## Motivation and Context

It matches `UICollectionViewFlowLayout` behavior, so I guess we should implement this workaround.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
