### PR TITLE
Fix empty section index path crash

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.1'
+  s.version  = '1.6.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -551,7 +551,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -571,7 +571,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     at elementIndexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
-   // If a supplementary view's visibility changes to `.hidden` due to a data source change, this
+    // If a supplementary view's visibility changes to `.hidden` due to a data source change, this
     // function will get invoked with an `elementIndexPath` that crashes when its `section` is
     // accessed.
     guard !elementIndexPath.isEmpty else {
@@ -616,6 +616,15 @@ public final class MagazineLayout: UICollectionViewLayout {
     at elementIndexPath: IndexPath)
     -> UICollectionViewLayoutAttributes?
   {
+    // If a supplementary view's visibility changes to `.hidden` due to a data source change, this
+    // function will get invoked with an `elementIndexPath` that crashes when its `section` is
+    // accessed.
+    guard !elementIndexPath.isEmpty else {
+      return super.finalLayoutAttributesForDisappearingSupplementaryElement(
+        ofKind: elementKind,
+        at: elementIndexPath)
+    }
+
     if modelState.sectionIndicesToDelete.contains(elementIndexPath.section) {
       let attributes = previousLayoutAttributesForSupplementaryView(
         ofKind: elementKind,


### PR DESCRIPTION
## Details

This PR is a follow up to https://github.com/airbnb/MagazineLayout/pull/63, which fixes an issue where UICollectionView passes an empty `IndexPath` object to the layout if a supplementary item is removed from the collection view. In this case, calling `indexPath.section` will crash (kind of crazy... but a relic from the Objective-C API design days I suppose).

The aforementioned PR only fixed it in `initialLayoutAttributesForAppearingSupplementaryElement`, but we need the same fix in `finalLayoutAttributesForDisappearingSupplementaryElement` to prevent all crashes.

## Related Issue

N/A

## Motivation and Context

Crash fix.

## How Has This Been Tested

Sample app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
