### PR TITLE
Better support for programmatic cell initialization 

### DIFF
--- a/MagazineLayout/Public/Views/MagazineLayoutCollectionReusableView.swift
+++ b/MagazineLayout/Public/Views/MagazineLayoutCollectionReusableView.swift
@@ -37,7 +37,6 @@ open class MagazineLayoutCollectionReusableView: UICollectionReusableView {
     -> UICollectionViewLayoutAttributes
   {
     guard let attributes = layoutAttributes as? MagazineLayoutCollectionViewLayoutAttributes else {
-      assertionFailure("`layoutAttributes` must be an instance of `MagazineLayoutCollectionViewLayoutAttributes`")
       return super.preferredLayoutAttributesFitting(layoutAttributes)
     }
 

--- a/MagazineLayout/Public/Views/MagazineLayoutCollectionViewCell.swift
+++ b/MagazineLayout/Public/Views/MagazineLayoutCollectionViewCell.swift
@@ -60,7 +60,6 @@ open class MagazineLayoutCollectionViewCell: UICollectionViewCell {
     -> UICollectionViewLayoutAttributes
   {
     guard let attributes = layoutAttributes as? MagazineLayoutCollectionViewLayoutAttributes else {
-      assertionFailure("`layoutAttributes` must be an instance of `MagazineLayoutCollectionViewLayoutAttributes`")
       return super.preferredLayoutAttributesFitting(layoutAttributes)
     }
 

--- a/MagazineLayout/Public/Views/MagazineLayoutCollectionViewCell.swift
+++ b/MagazineLayout/Public/Views/MagazineLayoutCollectionViewCell.swift
@@ -39,6 +39,22 @@ import UIKit
 /// Apple's own layout.
 open class MagazineLayoutCollectionViewCell: UICollectionViewCell {
 
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      contentView.topAnchor.constraint(equalTo: topAnchor),
+      contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      rightAnchor.constraint(equalTo: contentView.rightAnchor),
+    ])
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+
   override open func preferredLayoutAttributesFitting(
     _ layoutAttributes: UICollectionViewLayoutAttributes)
     -> UICollectionViewLayoutAttributes


### PR DESCRIPTION
## Details

<!--- Describe your changes in detail -->
The cell's `translatesAutoresizingMaskIntoConstraints` is `true` if created programmatically. Yet, the layout itself requires auto layout to work. The PR ensures all `contentView`'s edge constraints are set to the cell. Additionally, it removes limitation on cell to support other layout classes other than just `MagazineLayout`.

## Related Issue

<!--- If this is related to any issues, link them here. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
