### PR TITLE
Add automatic hashable and equatable conformances

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.3'
+  s.version  = '1.6.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -551,7 +551,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.3;
+				MARKETING_VERSION = 1.6.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/Public/Types/MagazineLayoutBackgroundVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutBackgroundVisibilityMode.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /// Represents the visibility mode for a background.
-public enum MagazineLayoutBackgroundVisibilityMode {
+public enum MagazineLayoutBackgroundVisibilityMode: Hashable {
 
   /// This visiblity mode will cause the background to be displayed behind the items and headers in
   /// its respective section.

--- a/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
@@ -17,7 +17,7 @@ import CoreGraphics
 // MARK: - MagazineLayoutFooterVisibilityMode
 
 /// Represents the visibility mode for a footer.
-public enum MagazineLayoutFooterVisibilityMode {
+public enum MagazineLayoutFooterVisibilityMode: Hashable {
 
   /// This visibility mode will cause the footer to be displayed using the specified height mode in
   /// its respective section. If `pinToVisibleBounds` is true, the footer will pin to the visible
@@ -41,7 +41,7 @@ public enum MagazineLayoutFooterVisibilityMode {
 // MARK: - MagazineLayoutFooterHeightMode
 
 /// Represents the vertical sizing mode for a footer.
-public enum MagazineLayoutFooterHeightMode {
+public enum MagazineLayoutFooterHeightMode: Hashable {
 
   /// This height mode will force the footer to be displayed with a height equal to `height`.
   ///
@@ -56,23 +56,5 @@ public enum MagazineLayoutFooterHeightMode {
   /// upfront. For example, if you support multiline labels or dynamic type, your height is likely
   /// not known until the Auto Layout engine resolves the layout at runtime.
   case dynamic
-
-}
-
-// MARK: Equatable
-
-extension MagazineLayoutFooterHeightMode: Equatable {
-
-  public static func == (
-    lhs: MagazineLayoutFooterHeightMode,
-    rhs: MagazineLayoutFooterHeightMode)
-    -> Bool
-  {
-    switch (lhs, rhs) {
-    case (.static(let l), .static(let r)): return l == r
-    case (.dynamic, .dynamic): return true
-    default: return false
-    }
-  }
 
 }

--- a/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
@@ -18,7 +18,7 @@ import CoreGraphics
 // MARK: - MagazineLayoutHeaderVisibilityMode
 
 /// Represents the visibility mode for a header.
-public enum MagazineLayoutHeaderVisibilityMode {
+public enum MagazineLayoutHeaderVisibilityMode: Hashable {
 
   /// This visibility mode will cause the header to be displayed using the specified height mode in
   /// its respective section. If `pinToVisibleBounds` is true, the header will pin to the visible
@@ -42,7 +42,7 @@ public enum MagazineLayoutHeaderVisibilityMode {
 // MARK: - MagazineLayoutHeaderHeightMode
 
 /// Represents the vertical sizing mode for a header.
-public enum MagazineLayoutHeaderHeightMode {
+public enum MagazineLayoutHeaderHeightMode: Hashable {
 
   /// This height mode will force the header to be displayed with a height equal to `height`.
   ///
@@ -57,23 +57,5 @@ public enum MagazineLayoutHeaderHeightMode {
   /// upfront. For example, if you support multiline labels or dynamic type, your height is likely
   /// not known until the Auto Layout engine resolves the layout at runtime.
   case dynamic
-
-}
-
-// MARK: Equatable
-
-extension MagazineLayoutHeaderHeightMode: Equatable {
-
-  public static func == (
-    lhs: MagazineLayoutHeaderHeightMode,
-    rhs: MagazineLayoutHeaderHeightMode)
-    -> Bool
-  {
-    switch (lhs, rhs) {
-    case (.static(let l), .static(let r)): return l == r
-    case (.dynamic, .dynamic): return true
-    default: return false
-    }
-  }
 
 }

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -18,7 +18,7 @@ import CoreGraphics
 // MARK: - MagazineLayoutItemSizeMode
 
 /// Represents the horizontal and vertical sizing mode for an item.
-public struct MagazineLayoutItemSizeMode {
+public struct MagazineLayoutItemSizeMode: Hashable {
 
   // MARK: Lifecycle
 
@@ -43,7 +43,7 @@ public struct MagazineLayoutItemSizeMode {
 ///
 /// Consecutive items with the same width mode will display on the same row until there is no more
 /// room.
-public enum MagazineLayoutItemWidthMode {
+public enum MagazineLayoutItemWidthMode: Hashable {
 
   /// Full width items will fill the available width in a section.
   ///
@@ -91,24 +91,6 @@ public enum MagazineLayoutItemWidthMode {
 
 }
 
-// MARK: Equatable
-
-extension MagazineLayoutItemWidthMode: Equatable {
-
-  public static func == (
-    lhs: MagazineLayoutItemWidthMode,
-    rhs: MagazineLayoutItemWidthMode)
-    -> Bool
-  {
-    switch (lhs, rhs) {
-    case (.fullWidth(let l), .fullWidth(let r)): return l == r
-    case (.fractionalWidth(let l), .fractionalWidth(let r)): return l == r
-    default: return false
-    }
-  }
-
-}
-
 // MARK: - MagazineLayoutItemHeightMode
 
 /// Represents the vertical sizing mode for an item.
@@ -116,7 +98,7 @@ extension MagazineLayoutItemWidthMode: Equatable {
 /// `MagazineLayout` supports vertically self-sizing and statically sized items. Since height modes
 /// are specified for each item, you can mix vertically self-sizing and statically sized items in
 /// the same sections, and even in the same rows.
-public enum MagazineLayoutItemHeightMode {
+public enum MagazineLayoutItemHeightMode: Hashable {
 
   /// This height mode mode will cause the item to be displayed with a height equal to `height`.
   ///
@@ -141,24 +123,5 @@ public enum MagazineLayoutItemHeightMode {
   /// Note that items with this height mode will resize to match the height of the tallest item in
   /// the same row of items, even if the tallest item has a `static` height mode.
   case dynamicAndStretchToTallestItemInRow
-
-}
-
-// MARK: Equatable
-
-extension MagazineLayoutItemHeightMode: Equatable {
-
-  public static func == (
-    lhs: MagazineLayoutItemHeightMode,
-    rhs: MagazineLayoutItemHeightMode)
-    -> Bool
-  {
-    switch (lhs, rhs) {
-    case (.static(let l), .static(let r)): return l == r
-    case (.dynamic, .dynamic): return true
-    case (.dynamicAndStretchToTallestItemInRow, .dynamicAndStretchToTallestItemInRow): return true
-    default: return false
-    }
-  }
 
 }


### PR DESCRIPTION
## Details

This removes the manual `Equatable` implementations and adds automatic `Hashable` conformances for public types. I imagine some people will find these automatic conformances useful in their feature code (Airbnb, for example 😆)

## Related Issue

N/A

## Motivation and Context

- Remove error-prone manual `Equatable` conformances
- Having them be `Hashable` means people's feature code can store these types in sets and dictionaries, or as properties in other `Hashable` / `Equatable` types

## How Has This Been Tested

Made sure the Example app built and ran correctly

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
