### PR TITLE
Maintain the same visible items after rotation

### DIFF
--- a/Example/MagazineLayoutExample/Views/Footer.swift
+++ b/Example/MagazineLayoutExample/Views/Footer.swift
@@ -37,7 +37,7 @@ final class Footer: MagazineLayoutCollectionReusableView {
       label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
       label.topAnchor.constraint(equalTo: topAnchor),
       label.bottomAnchor.constraint(equalTo: bottomAnchor),
-      ])
+    ])
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.4'
+  s.version  = '1.6.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.6.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -551,7 +551,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.6.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details

This makes it so that `MagazineLayout` will maintain a similar scroll position after rotation. It does this by introducing some additional bookkeeping so that we know which item was closest to the top before the rotation. We then ensure that our target content offset positions this item at the top after rotation. 

As usual, `UICollectionViewLayout` is an undocumented, confusing mystery. 4 calls to `prepare(forAnimatedBoundsChange oldBounds:)` for one rotation? Makes sense!

<img width="692" alt="image" src="https://user-images.githubusercontent.com/746571/145541793-9d0e6cef-1fb2-4385-9328-ac83940cff34.png">

## Related Issue

N/A

## Motivation and Context

Slight behavior improvement - nothing major.

## How Has This Been Tested

Tested on iOS simulator; iPhone and iPad.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
