### PR TITLE
Add GitHub Actions support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,24 @@
+name: Swift
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        destination: ['platform=iOS Simulator,OS=10.0,name=iPhone 7', 'platform=iOS Simulator,OS=15.0,name=iPhone 13']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: xcodebuild clean build -scheme MagazineLayout
+    - name: Run tests
+      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 8,OS=15.0"
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.5.3'
-end

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # MagazineLayout
 A collection view layout capable of laying out views in vertically scrolling grids and lists.
 
+[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://img.shields.io/cocoapods/v/MagazineLayout.svg)](https://cocoapods.org/pods/MagazineLayout)
 [![License](https://img.shields.io/cocoapods/l/MagazineLayout.svg)](https://cocoapods.org/pods/MagazineLayout)
 [![Platform](https://img.shields.io/cocoapods/p/MagazineLayout.svg)](https://cocoapods.org/pods/MagazineLayout)
-[![Build Status](https://travis-ci.com/airbnb/MagazineLayout.svg?token=yiLD1pPhUW32MDs2wsVE&branch=master)](https://travis-ci.com/airbnb/MagazineLayout)
+![Swift](https://github.com/airbnb/MagazineLayout/workflows/Swift/badge.svg)
 
 
 ## Introduction


### PR DESCRIPTION
## Details

This removes support for Travis CI (which doesn't seem to be working) and adds support for CI via GitHub Actions. This is what I was using for HorizonCalendar anyways, so having them both use GitHub's first-party CI solution seems like a good improvement.

Gonna merge through without a review to fix CI.
