### PR TITLE
Make CGFloat comparison safer

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=10.0,name=iPhone 7', 'platform=iOS Simulator,OS=15.0,name=iPhone 13']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=15.2,name=iPhone 12']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme MagazineLayout
     - name: Run tests
-      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 8,OS=15.0"
+      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 8,OS=15.2"
 

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.5'
+  s.version  = '1.6.6'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */; };
 		93424B012256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */; };
+		93540AB0282E25D90008BD6F /* CGFloatApproximateEquality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93540AAF282E25D90008BD6F /* CGFloatApproximateEquality.swift */; };
+		93540AB2282E26340008BD6F /* CGFloatApproximateEquality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93540AB1282E26340008BD6F /* CGFloatApproximateEquality.swift */; };
 		9398462A2296864200E442DA /* RowOffsetTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939846292296864200E442DA /* RowOffsetTracker.swift */; };
 		93A1BFF921ACE9A000DED67D /* MagazineLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A1BFEF21ACE9A000DED67D /* MagazineLayout.framework */; };
 		93A1C03521ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1C01621ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift */; };
@@ -54,6 +56,8 @@
 /* Begin PBXFileReference section */
 		9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowOffsetTrackerTests.swift; sourceTree = "<group>"; };
 		93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutFooterVisibilityMode.swift; sourceTree = "<group>"; };
+		93540AAF282E25D90008BD6F /* CGFloatApproximateEquality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatApproximateEquality.swift; sourceTree = "<group>"; };
+		93540AB1282E26340008BD6F /* CGFloatApproximateEquality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatApproximateEquality.swift; sourceTree = "<group>"; };
 		939846292296864200E442DA /* RowOffsetTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowOffsetTracker.swift; sourceTree = "<group>"; };
 		93A1BFEF21ACE9A000DED67D /* MagazineLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MagazineLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		93A1BFF821ACE9A000DED67D /* MagazineLayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MagazineLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +146,7 @@
 				93A1C00F21ACED0100DED67D /* ElementLocationFramePairsTests.swift */,
 				9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */,
 				93A1C00E21ACED0100DED67D /* TestingSupport.swift */,
+				93540AB1282E26340008BD6F /* CGFloatApproximateEquality.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -204,6 +209,7 @@
 				93A1C02121ACED0100DED67D /* ElementLocation.swift */,
 				93A1C02521ACED0100DED67D /* ElementLocationFramePairs.swift */,
 				939846292296864200E442DA /* RowOffsetTracker.swift */,
+				93540AAF282E25D90008BD6F /* CGFloatApproximateEquality.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -346,6 +352,7 @@
 				93A1C03A21ACED0100DED67D /* MagazineLayout.swift in Sources */,
 				93A1C04021ACED0100DED67D /* CollectionViewUpdateItem.swift in Sources */,
 				FCAC642622085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift in Sources */,
+				93540AB0282E25D90008BD6F /* CGFloatApproximateEquality.swift in Sources */,
 				93A1C03B21ACED0100DED67D /* MagazineLayoutInvalidationContext.swift in Sources */,
 				93A1C04621ACED0100DED67D /* HeaderModel.swift in Sources */,
 			);
@@ -361,6 +368,7 @@
 				93A1C04921ACED1100DED67D /* ModelStateEmptySectionLayoutTests.swift in Sources */,
 				93A1C04F21ACED1100DED67D /* ModelStateUpdateTests.swift in Sources */,
 				93A1C04D21ACED1100DED67D /* TestingSupport.swift in Sources */,
+				93540AB2282E26340008BD6F /* CGFloatApproximateEquality.swift in Sources */,
 				93A1C04E21ACED1100DED67D /* ElementLocationFramePairsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -523,7 +531,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.5;
+				MARKETING_VERSION = 1.6.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -551,7 +559,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.5;
+				MARKETING_VERSION = 1.6.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/LayoutCore/Types/CGFloatApproximateEquality.swift
+++ b/MagazineLayout/LayoutCore/Types/CGFloatApproximateEquality.swift
@@ -1,5 +1,5 @@
-// Created by bryankeller on 10/15/18.
-// Copyright © 2018 Airbnb, Inc.
+// Created by Bryan Keller on 5/12/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Represents the visibility mode for a background.
-public enum MagazineLayoutBackgroundVisibilityMode: Hashable {
+import CoreGraphics
 
-  /// This visibility mode will cause the background to be displayed behind the items and headers in
-  /// its respective section.
-  case visible
+extension CGFloat {
 
-  /// This visibility mode will cause the background to not be visible behind the items and headers
-  /// in its respective section.
-  case hidden
+  /// Tests `self` for approximate equality using the threshold value. For example, 1.48 equals 1.52 if the threshold is 0.05.
+  /// `threshold` will be treated as a positive value by taking its absolute value.
+  func isEqual(to rhs: CGFloat, threshold: CGFloat) -> Bool {
+    abs(self - rhs) <= abs(threshold)
+  }
 
 }

--- a/MagazineLayout/LayoutCore/Types/ElementLocation.swift
+++ b/MagazineLayout/LayoutCore/Types/ElementLocation.swift
@@ -35,7 +35,7 @@ struct ElementLocation: Hashable {
       sectionIndex = indexPath.section
     } else {
       // `UICollectionViewFlowLayout` is able to work with empty index paths (`IndexPath()`). Per
-      // the `IndexPath` documntation, an index path that uses `section` or `item` must have exactly
+      // the `IndexPath` documentation, an index path that uses `section` or `item` must have exactly
       // 2 elements. If not, we default to {0, 0} to prevent crashes.
       elementIndex = 0
       sectionIndex = 0

--- a/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutFooterVisibilityMode.swift
@@ -24,7 +24,7 @@ public enum MagazineLayoutFooterVisibilityMode: Hashable {
   /// bounds of the collection view while its containing section is visible.
   case visible(heightMode: MagazineLayoutFooterHeightMode, pinToVisibleBounds: Bool)
 
-  /// This visibility mode will cause the footer to not be visibile in its respective section.
+  /// This visibility mode will cause the footer to not be visible in its respective section.
   case hidden
 
   /// This visibility mode will cause the footer to be displayed using the specified height mode in

--- a/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutHeaderVisibilityMode.swift
@@ -25,7 +25,7 @@ public enum MagazineLayoutHeaderVisibilityMode: Hashable {
   /// bounds of the collection view while its containing section is visible.
   case visible(heightMode: MagazineLayoutHeaderHeightMode, pinToVisibleBounds: Bool)
 
-  /// This visibility mode will cause the header to not be visibile in its respective section.
+  /// This visibility mode will cause the header to not be visible in its respective section.
   case hidden
 
   /// This visibility mode will cause the header to be displayed using the specified height mode in

--- a/Tests/CGFloatApproximateEquality.swift
+++ b/Tests/CGFloatApproximateEquality.swift
@@ -1,0 +1,39 @@
+// Created by Bryan Keller on 5/12/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+// Created by Bryan Keller on 3/31/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import MagazineLayout
+
+final class CGFloatApproximateEqualityTests: XCTestCase {
+
+  func testApproximateEquality() {
+    XCTAssert(CGFloat(1.48).isEqual(to: 1.52, threshold: 0.05))
+    XCTAssert(!CGFloat(1.48).isEqual(to: 1.53, threshold: 0.05))
+
+    XCTAssert(CGFloat(1).isEqual(to: 10, threshold: 9))
+    XCTAssert(!CGFloat(1).isEqual(to: 11, threshold: 9))
+
+    XCTAssert(CGFloat(1).isEqual(to: 10, threshold: 9))
+    XCTAssert(!CGFloat(1).isEqual(to: 11, threshold: 9))
+
+    XCTAssert(CGFloat(1.333).isEqual(to: 1.666, threshold: 1 / 3))
+    XCTAssert(!CGFloat(1.332).isEqual(to: 1.666, threshold: 1 / 3))
+  }
+
+}
+


### PR DESCRIPTION
## Details

This improves the safety of some CGFloat comparison operations done in the layout. Comparing floats can be error-prone due to precision issues, and rounding actually isn't a great solution since 100.49999 and 100.50 will be unequal, even though they're incredibly close.

## Related Issue

N/A

## Motivation and Context

Crash fix attempt / general improvement

## How Has This Been Tested

Simulator and unt tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
