### PR TITLE
Fix mutable pointer errors

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.7'
+  s.version  = '1.6.8'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.7;
+				MARKETING_VERSION = 1.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -559,7 +559,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.7;
+				MARKETING_VERSION = 1.6.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/LayoutCore/Types/RowOffsetTracker.swift
+++ b/MagazineLayout/LayoutCore/Types/RowOffsetTracker.swift
@@ -33,16 +33,16 @@ struct RowOffsetTracker {
 
     // Accessing this array using an unsafe, untyped (raw) pointer avoids expensive copy-on-writes
     // and Swift retain / release calls.
-    let rowOffsetsPointer = UnsafeMutableRawPointer(mutating: &rowOffsets)
-    let directlyMutableRowOffsets = rowOffsetsPointer.assumingMemoryBound(to: CGFloat.self)
-    directlyMutableRowOffsets[rowIndex] = rowOffsets[rowIndex] + offset
+    rowOffsets.withUnsafeMutableBufferPointer { directlyMutableRowOffsets in
+      directlyMutableRowOffsets[rowIndex] = directlyMutableRowOffsets[rowIndex] + offset
 
-    while rowIndex > 1 {
-      rowIndex /= 2
+      while rowIndex > 1 {
+        rowIndex /= 2
 
-      let leftChild = rowOffsets[2 * rowIndex]
-      let rightChild = rowOffsets[(2 * rowIndex) + 1]
-      directlyMutableRowOffsets[rowIndex] = leftChild + rightChild
+        let leftChild = directlyMutableRowOffsets[2 * rowIndex]
+        let rightChild = directlyMutableRowOffsets[(2 * rowIndex) + 1]
+        directlyMutableRowOffsets[rowIndex] = leftChild + rightChild
+      }
     }
   }
 


### PR DESCRIPTION
## Details

This fixes dangling pointer warnings. The correct way to do this is the `.withUnsafeMutableBufferPointer` API, which ensures safe (direct) access to the underlying array storage.

## Related Issue

N/A

## Motivation and Context

Fix project warnings and who knows, maybe this will fix some of the rare memory corruption crashes I've seen before.

## How Has This Been Tested

Unit tests, real device testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
