### PR TITLE
Bk/crash fix lazy layout attributes

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.8'
+  s.version  = '1.6.9'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -536,7 +536,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.8;
+				MARKETING_VERSION = 1.6.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -564,7 +564,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.8;
+				MARKETING_VERSION = 1.6.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Details

This PR fixes an iOS 15+ layout loop crash.

```
NSInternalInconsistencyException: UICollectionView (<EpoxyCollectionView.CollectionView 0x110affa00>) is stuck in
its update/layout loop. This can happen for many reasons, including self-sizing views whose preferred attributes are
not returning a consistent size. To debug this issue, check the Console app for logs in the "UICollectionViewRecursion" category.
```

The root cause of the crash seems to be `UICollectionView` internally calling `setIndexPath` on an existing layout attributes instance. For example, a layout attributes instance that was initialized with the index path {0, 0} can later be internally updated to have its index path equal to {0, 1}. Because `UICollectionViewLayoutAttributes` is a reference type, when its index path is updated, our layout attributes cache which is keyed by index path is put into an invalid state. For example:

Valid layout attributes cache:
```swift
[
  {0, 0}: Layout attributes for {0, 0},
  {0, 1}: Layout attributes for {0, 1},
  {0, 2}: Layout attributes for {0, 2},
  {0, 3}: Layout attributes for {0, 3},
]
```

Invalid layout attributes cache:
```swift
[
  {0, 0}: Layout attributes for {0, 1}, // Now there are 2 entries for the item at {0, 1}, potentially with different size.height values
  {0, 1}: Layout attributes for {0, 1},
  {0, 2}: Layout attributes for {0, 2},
  {0, 3}: Layout attributes for {0, 3},
]
```

To work around this, I've made a few changes:
1. Create and cache layout attributes just-in-time, rather than in `prepareLayout`. 
2. Ignore the cached layout attributes if the index path cache key != the corresponding layout attributes' index path

## Related Issue

N/A

## Motivation and Context

Crash fix and performance improvement.

## How Has This Been Tested

Demo app that consistently reproduced the aforementioned crash prior to my fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
