### PR TITLE
Fix number of sections being out of bounds crash

### DIFF
--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.9'
+  s.version  = '1.6.10'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -536,7 +536,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.9;
+				MARKETING_VERSION = 1.6.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -564,7 +564,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.9;
+				MARKETING_VERSION = 1.6.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.MagazineLayout;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -367,23 +367,22 @@ public final class MagazineLayout: UICollectionViewLayout {
     // See comment in `layoutAttributesForElementsInRect:` for more details.
     guard !hasDataSourceCountInvalidationBeforeReceivingUpdateItems else { return nil }
 
+
+    // For reasons that are not clear, this function can be invoked with with an out-of-bounds
+    // index path. To guard against downstream index-out-of-bounds crashes, we return nil here if we
+    // detect this scenario.
+
+    let numberOfSections = min(
+      currentCollectionView.numberOfSections,
+      modelState.numberOfSections(.afterUpdates))
+    guard indexPath.section < numberOfSections else { return nil }
+
+    let numberOfItems = min(
+      currentCollectionView.numberOfItems(inSection: indexPath.section),
+      modelState.numberOfItems(inSectionAtIndex: indexPath.section, .afterUpdates))
+    guard indexPath.item < numberOfItems else { return nil }
+
     let itemLocation = ElementLocation(indexPath: indexPath)
-
-    guard
-      itemLocation.sectionIndex < modelState.numberOfSections(.afterUpdates),
-      itemLocation.elementIndex < modelState.numberOfItems(inSectionAtIndex: itemLocation.sectionIndex, .afterUpdates)
-    else
-    {
-      // On iOS 9, `layoutAttributesForItem(at:)` can be invoked for an index path of a new item
-      // before the layout is notified of this new item (through either `prepare` or
-      // `prepare(forCollectionViewUpdates:)`). This seems to be fixed in iOS 10 and higher.
-      assertionFailure("`{\(itemLocation.sectionIndex), \(itemLocation.elementIndex)}` is out of bounds of the section models / item models array.")
-
-      // Returning `nil` rather than default/frameless layout attributes causes internal exceptions
-      // within `UICollectionView`, which is why we don't return `nil` here.
-      return itemLayoutAttributes(for: itemLocation, frame: .zero)
-    }
-
     let itemFrame = modelState.frameForItem(at: itemLocation, .afterUpdates)
     return itemLayoutAttributes(for: itemLocation, frame: itemFrame)
   }
@@ -771,7 +770,17 @@ public final class MagazineLayout: UICollectionViewLayout {
       prepareActions.formUnion([.updateLayoutMetrics])
     }
 
-    hasDataSourceCountInvalidationBeforeReceivingUpdateItems = context.invalidateDataSourceCounts &&
+    // The layout can be invalidated with `invalidateDataSourceCounts == false` even though the
+    // number of sections has changed. An invalidation in the near future will have
+    // `invalidateDataSourceCounts == true`, but at that point, other layout functions like
+    // `prepare` have already been called.
+    // To prevent section-out-of-bounds calls to `numberOfItems(inSection:)`, we need to track this
+    // scenario using `hasDataSourceCountInvalidationBeforeReceivingUpdateItems`.
+    let numberOfDataSourceSections = currentCollectionView.numberOfSections
+    let numberOfModelStateSections = modelState.numberOfSections(.afterUpdates)
+    let numberOfSectionsChanged = numberOfDataSourceSections != numberOfModelStateSections
+    let dataSourceCountsChanged = numberOfSectionsChanged || context.invalidateDataSourceCounts
+    hasDataSourceCountInvalidationBeforeReceivingUpdateItems = dataSourceCountsChanged &&
       !context.invalidateEverything
 
     super.invalidateLayout(with: context)

--- a/MagazineLayout/Public/MagazineLayoutInvalidationContext.swift
+++ b/MagazineLayout/Public/MagazineLayoutInvalidationContext.swift
@@ -25,3 +25,19 @@ public final class MagazineLayoutInvalidationContext: UICollectionViewLayoutInva
   public var invalidateLayoutMetrics = true
 
 }
+
+// MARK: CustomDebugStringConvertible
+
+extension MagazineLayoutInvalidationContext {
+
+  public override var debugDescription: String {
+    "Invalidate: everything - \(invalidateEverything), " +
+    "data source counts - \(invalidateDataSourceCounts), " +
+    "offset adjustment - \(contentOffsetAdjustment), " +
+    "size adjustment - \(contentSizeAdjustment), " +
+    "item index paths - \(String(describing: invalidatedItemIndexPaths)), " +
+    "supplementary index paths - \(String(describing: invalidatedSupplementaryIndexPaths)), " +
+    "decoration index paths - \(String(describing: invalidatedDecorationIndexPaths))"
+  }
+
+}


### PR DESCRIPTION
## Details

`layoutAttributesForItemAt:` can be invoked with an out-of-bounds index path. Previous comments in code seem to indicate that this is not a new issue.

I believe the root of all of these issues is that the layout can be invalidated in between when the data source counts change (from a batch update), and when the layout actually receives an invalidate context specifying that data source counts have changed. This behavior sucks, and I don't see a clear way to work around this. This is something that I chatted about with a UICollectionView engineer back in 2019, and that person made it sound like they were using some private APIs in the layout to work around this 😩

## Related Issue

N/A

## Motivation and Context

Crash / assertion "fix" / workaround

## How Has This Been Tested

Example project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
