### PR TITLE
Fix data source index OOB crash

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -323,8 +323,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       let headerLocation = headerLocationFramePair.elementLocation
       let headerFrame = headerLocationFramePair.frame
 
-      let layoutAttributes = headerLayoutAttributes(for: headerLocation, frame: headerFrame)
-      layoutAttributesInRect.append(layoutAttributes)
+      if let layoutAttributes = headerLayoutAttributes(for: headerLocation, frame: headerFrame) {
+        layoutAttributesInRect.append(layoutAttributes)
+      }
     }
 
     let footerLocationFramePairs = modelState.footerLocationFramePairs(forFootersIn: rect)
@@ -332,8 +333,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       let footerLocation = footerLocationFramePair.elementLocation
       let footerFrame = footerLocationFramePair.frame
 
-      let layoutAttributes = footerLayoutAttributes(for: footerLocation, frame: footerFrame)
-      layoutAttributesInRect.append(layoutAttributes)
+      if let layoutAttributes = footerLayoutAttributes(for: footerLocation, frame: footerFrame) {
+        layoutAttributesInRect.append(layoutAttributes)
+      }
     }
 
     let backgroundLocationFramePairs = modelState.backgroundLocationFramePairs(
@@ -342,10 +344,13 @@ public final class MagazineLayout: UICollectionViewLayout {
       let backgroundLocation = backgroundLocationFramePair.elementLocation
       let backgroundFrame = backgroundLocationFramePair.frame
 
-      let layoutAttributes = backgroundLayoutAttributes(
-        for: backgroundLocation,
-        frame: backgroundFrame)
-      layoutAttributesInRect.append(layoutAttributes)
+      if
+        let layoutAttributes = backgroundLayoutAttributes(
+          for: backgroundLocation,
+          frame: backgroundFrame)
+      {
+        layoutAttributesInRect.append(layoutAttributes)
+      }
     }
 
     let itemLocationFramePairs = modelState.itemLocationFramePairs(forItemsIn: rect)
@@ -353,8 +358,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       let itemLocation = itemLocationFramePair.elementLocation
       let itemFrame = itemLocationFramePair.frame
 
-      let layoutAttributes = itemLayoutAttributes(for: itemLocation, frame: itemFrame)
-      layoutAttributesInRect.append(layoutAttributes)
+      if let layoutAttributes = itemLayoutAttributes(for: itemLocation, frame: itemFrame) {
+        layoutAttributesInRect.append(layoutAttributes)
+      }
     }
 
     return layoutAttributesInRect
@@ -1223,8 +1229,10 @@ private extension MagazineLayout {
   func headerLayoutAttributes(
     for headerLocation: ElementLocation,
     frame: CGRect)
-    -> UICollectionViewLayoutAttributes
+    -> UICollectionViewLayoutAttributes?
   {
+    guard headerLocation.sectionIndex < currentCollectionView.numberOfSections else { return nil }
+
     let layoutAttributes: MagazineLayoutCollectionViewLayoutAttributes
     if
       let cachedLayoutAttributes = headerLayoutAttributes[headerLocation],
@@ -1259,8 +1267,10 @@ private extension MagazineLayout {
   func footerLayoutAttributes(
     for footerLocation: ElementLocation,
     frame: CGRect)
-    -> UICollectionViewLayoutAttributes
+    -> UICollectionViewLayoutAttributes?
   {
+    guard footerLocation.sectionIndex < currentCollectionView.numberOfSections else { return nil }
+
     let layoutAttributes: MagazineLayoutCollectionViewLayoutAttributes
     if
       let cachedLayoutAttributes = footerLayoutAttributes[footerLocation],
@@ -1295,8 +1305,12 @@ private extension MagazineLayout {
   func backgroundLayoutAttributes(
     for backgroundLocation: ElementLocation,
     frame: CGRect)
-    -> UICollectionViewLayoutAttributes
+    -> UICollectionViewLayoutAttributes?
   {
+    guard backgroundLocation.sectionIndex < currentCollectionView.numberOfSections else {
+      return nil
+    }
+
     let layoutAttributes: MagazineLayoutCollectionViewLayoutAttributes
     if
       let cachedLayoutAttributes = backgroundLayoutAttributes[backgroundLocation],
@@ -1322,8 +1336,12 @@ private extension MagazineLayout {
   func itemLayoutAttributes(
     for itemLocation: ElementLocation,
     frame: CGRect)
-    -> UICollectionViewLayoutAttributes
+    -> UICollectionViewLayoutAttributes?
   {
+    guard itemLocation.sectionIndex < currentCollectionView.numberOfSections else { return nil }
+    let numberOfItems = currentCollectionView.numberOfItems(inSection: itemLocation.sectionIndex)
+    guard itemLocation.elementIndex < numberOfItems else { return nil }
+
     let layoutAttributes: MagazineLayoutCollectionViewLayoutAttributes
     if
       let cachedLayoutAttributes = itemLayoutAttributes[itemLocation],
@@ -1344,7 +1362,6 @@ private extension MagazineLayout {
       layoutAttributes.shouldVerticallySelfSize = true
     }
 
-    let numberOfItems = currentCollectionView.numberOfItems(inSection: itemLocation.sectionIndex)
     layoutAttributes.zIndex = numberOfItems - itemLocation.elementIndex
 
     itemLayoutAttributes[itemLocation] = layoutAttributes


### PR DESCRIPTION
## Details

This is an alternative fix / approach to [fixing the data source count / internal model state mismatch](https://github.com/airbnb/MagazineLayout/pull/108) that occurs when `UICollectionView` requests layout attributes before the layout has been notified about incoming batch updates.

This bug became an issue after the [layout loop fix PR](https://github.com/airbnb/MagazineLayout/pull/107) was merged last week. That PR changed how we create layout attributes (no longer done in `prepareLayout`, and instead done lazily as layout attributes are requested for specific index paths). This behavior change assumed that `UICollectionView` would never try to request layout attributes for out-of-bounds index paths. Unfortunately, this is not a safe assumption.

This PR changes our layout attributes creation code so that it returns `nil` if we detect an out-of-bounds index path. This is effectively how `MagazineLayout` behaved prior to the [layout loop fix PR](https://github.com/airbnb/MagazineLayout/pull/107). Reverting this behavior has no impact on the layout loop fix, which will continue to work.

Also note that I'm not bumping the version / pushing a new release. I'll verify this works properly in the Airbnb iOS app, and if all looks good, then I'll push a new tag / make a new release.

## Related Issue

N/A

## Motivation and Context

Fix a crash.

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
