### PR TITLE
Use displayScale instead of UIScreen.main

### DIFF
--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		93A1C04F21ACED1100DED67D /* ModelStateUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1C01021ACED0100DED67D /* ModelStateUpdateTests.swift */; };
 		FCAC642622085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAC642522085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift */; };
 		FCAC642822085B0E00973F4C /* FooterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAC642722085B0E00973F4C /* FooterModel.swift */; };
+		FD244FEF28B41F9900046C0D /* UITraitCollection+DisplayScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD244FEE28B41F9900046C0D /* UITraitCollection+DisplayScale.swift */; };
 		FD4DFF0821B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4DFF0721B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift */; };
 		FD4DFF0A21B0D182001F46CE /* MagazineLayoutCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4DFF0921B0D181001F46CE /* MagazineLayoutCollectionReusableView.swift */; };
 		FDF6E15B21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF6E15A21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift */; };
@@ -89,6 +90,7 @@
 		FCAC642522085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutHeaderVisibilityMode.swift; sourceTree = "<group>"; };
 		FCAC642722085B0E00973F4C /* FooterModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FooterModel.swift; sourceTree = "<group>"; };
 		FD23F5F021AF4A1B00AA78D4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FD244FEE28B41F9900046C0D /* UITraitCollection+DisplayScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITraitCollection+DisplayScale.swift"; sourceTree = "<group>"; };
 		FD4DFF0721B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionViewCell.swift; sourceTree = "<group>"; };
 		FD4DFF0921B0D181001F46CE /* MagazineLayoutCollectionReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionReusableView.swift; sourceTree = "<group>"; };
 		FD69EA0F21BA01E6001E0650 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				93A1C02521ACED0100DED67D /* ElementLocationFramePairs.swift */,
 				939846292296864200E442DA /* RowOffsetTracker.swift */,
 				93540AAF282E25D90008BD6F /* ScreenPixelAlignment.swift */,
+				FD244FEE28B41F9900046C0D /* UITraitCollection+DisplayScale.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				93A1C04521ACED0100DED67D /* ItemModel.swift in Sources */,
 				93A1C03F21ACED0100DED67D /* MagazineLayoutSectionMetrics.swift in Sources */,
 				93A1C03A21ACED0100DED67D /* MagazineLayout.swift in Sources */,
+				FD244FEF28B41F9900046C0D /* UITraitCollection+DisplayScale.swift in Sources */,
 				93A1C04021ACED0100DED67D /* CollectionViewUpdateItem.swift in Sources */,
 				FCAC642622085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift in Sources */,
 				93540AB0282E25D90008BD6F /* ScreenPixelAlignment.swift in Sources */,

--- a/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
+++ b/MagazineLayout/LayoutCore/Types/MagazineLayoutSectionMetrics.swift
@@ -54,7 +54,7 @@ struct MagazineLayoutSectionMetrics: Equatable {
       layout: layout,
       insetsForItemsInSectionAtIndex: sectionIndex)
 
-    scale = collectionView.window?.screen.scale ?? UIScreen.main.scale
+    scale = collectionView.traitCollection.nonZeroDisplayScale
   }
 
   private init(

--- a/MagazineLayout/LayoutCore/Types/UITraitCollection+DisplayScale.swift
+++ b/MagazineLayout/LayoutCore/Types/UITraitCollection+DisplayScale.swift
@@ -1,0 +1,27 @@
+// Created by Bryan Keller on 8/22/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+extension UITraitCollection {
+
+  // The documentation mentions that 0 is a possible value, so we guard against this.
+  // It's unclear whether values between 0 and 1 are possible, otherwise `max(scale, 1)` would
+  // suffice.
+  var nonZeroDisplayScale: CGFloat {
+    displayScale > 0 ? displayScale : 1
+  }
+
+}

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -903,7 +903,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   private var scale: CGFloat {
-    collectionView?.window?.screen.scale ?? UIScreen.main.scale
+    collectionView?.traitCollection.nonZeroDisplayScale ?? 1
   }
 
   private func metricsForSection(atIndex sectionIndex: Int) -> MagazineLayoutSectionMetrics {


### PR DESCRIPTION
## Details

`UIScreen.main` is being deprecated in iOS 16. We should be able to just use the trait collection's `displayScale` property. All seems to work correctly in my testing.

## Related Issue

N/A

## Motivation and Context

Adopting latest APIs.

## How Has This Been Tested

Example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
