### PR TITLE
Allow input estimate height for height mode dynamic

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -933,11 +933,20 @@ public final class MagazineLayout: UICollectionViewLayout {
       sizeModeForItemAt: indexPath)
   }
 
-  private func initialItemHeight(from itemSizeMode: MagazineLayoutItemSizeMode) -> CGFloat {
+  private func initialItemHeight(
+    from itemSizeMode: MagazineLayoutItemSizeMode,
+    indexPath: IndexPath)
+    -> CGFloat {
     switch itemSizeMode.heightMode {
     case let .static(staticHeight):
       return staticHeight
     case .dynamic, .dynamicAndStretchToTallestItemInRow:
+      if let delegateMagazineLayout, let collectionView {
+        return delegateMagazineLayout.collectionView(collectionView,
+                                                     layout: self,
+                                                     estimateHeightFor: indexPath)
+      }
+
       return MagazineLayout.Default.ItemHeight
     }
   }
@@ -1025,7 +1034,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     let itemSizeMode = sizeModeForItem(at: indexPath)
     return ItemModel(
       sizeMode: itemSizeMode,
-      height: initialItemHeight(from: itemSizeMode))
+      height: initialItemHeight(from: itemSizeMode, indexPath: indexPath))
   }
 
   private func headerModelForHeader(

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -933,20 +933,13 @@ public final class MagazineLayout: UICollectionViewLayout {
       sizeModeForItemAt: indexPath)
   }
 
-  private func initialItemHeight(
-    from itemSizeMode: MagazineLayoutItemSizeMode,
-    indexPath: IndexPath)
-    -> CGFloat {
+  private func initialItemHeight(from itemSizeMode: MagazineLayoutItemSizeMode) -> CGFloat {
     switch itemSizeMode.heightMode {
     case let .static(staticHeight):
       return staticHeight
-    case .dynamic, .dynamicAndStretchToTallestItemInRow:
-      if let delegateMagazineLayout, let collectionView {
-        return delegateMagazineLayout.collectionView(collectionView,
-                                                     layout: self,
-                                                     estimateHeightFor: indexPath)
-      }
-
+    case let .dynamic(estimatedHeight):
+      return estimatedHeight
+    case .dynamicAndStretchToTallestItemInRow:
       return MagazineLayout.Default.ItemHeight
     }
   }
@@ -1034,7 +1027,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     let itemSizeMode = sizeModeForItem(at: indexPath)
     return ItemModel(
       sizeMode: itemSizeMode,
-      height: initialItemHeight(from: itemSizeMode, indexPath: indexPath))
+      height: initialItemHeight(from: itemSizeMode))
   }
 
   private func headerModelForHeader(

--- a/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutItemSizeMode.swift
@@ -106,13 +106,14 @@ public enum MagazineLayoutItemHeightMode: Hashable {
   /// the height of your items dynamically, consider using one of the dynamic height modes.
   case `static`(height: CGFloat)
 
-  /// This height mode will cause the item to self-size in the vertical direction.
+  /// This height mode will cause the item to self-size in the vertical direction, using the `estimatedHeight` as an initial
+  /// placeholder.
   ///
   /// In practice, self-sizing in the vertical direction means that the item will get its height
   /// from the Auto Layout engine. Use this height mode for items whose height is not known upfront.
   /// For example, if you support multiline labels or dynamic type, your height is likely not known
   /// until the Auto Layout engine resolves the layout at runtime.
-  case dynamic
+  case dynamic(estimatedHeight: CGFloat)
 
   /// This height mode will cause the item to self-size in the vertical direction, then resize to
   /// match the height of the tallest item in the same row of items.
@@ -123,5 +124,15 @@ public enum MagazineLayoutItemHeightMode: Hashable {
   /// Note that items with this height mode will resize to match the height of the tallest item in
   /// the same row of items, even if the tallest item has a `static` height mode.
   case dynamicAndStretchToTallestItemInRow
+
+  /// This height mode will cause the item to self-size in the vertical direction
+  ///
+  /// In practice, self-sizing in the vertical direction means that the item will get its height
+  /// from the Auto Layout engine. Use this height mode for items whose height is not known upfront.
+  /// For example, if you support multiline labels or dynamic type, your height is likely not known
+  /// until the Auto Layout engine resolves the layout at runtime.
+  public static var dynamic: MagazineLayoutItemHeightMode {
+    .dynamic(estimatedHeight: MagazineLayout.Default.ItemHeight)
+  }
 
 }

--- a/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
+++ b/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
@@ -33,6 +33,20 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     sizeModeForItemAt indexPath: IndexPath)
     -> MagazineLayoutItemSizeMode
 
+  ///   Asks the delegate for the estimate height of the specified item.
+  ///
+  ///   - Parameters:
+  ///      - collectionView: The collection view using the layout.
+  ///      - collectionViewLayout: The layout requesting the information.
+  ///      - indexPath: The index path of the item.
+  ///
+  ///   - Returns: The estimate height of the specified item.
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    estimateHeightFor indexPath: IndexPath)
+    -> CGFloat
+
   ///   Asks the delegate for the visibility mode of the header in the specified section.
   ///
   ///   - Parameters:
@@ -288,6 +302,17 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     finalLayoutAttributesForRemovedBackgroundInSectionAtIndex index: Int,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
 
+}
+
+// MARK: - Default estimate height
+public extension UICollectionViewDelegateMagazineLayout {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    estimateHeightFor indexPath: IndexPath)
+    -> CGFloat {
+      return MagazineLayout.Default.ItemHeight
+  }
 }
 
 // MARK: Default Insert Animations

--- a/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
+++ b/MagazineLayout/Public/UICollectionViewDelegateMagazineLayout.swift
@@ -33,20 +33,6 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     sizeModeForItemAt indexPath: IndexPath)
     -> MagazineLayoutItemSizeMode
 
-  ///   Asks the delegate for the estimate height of the specified item.
-  ///
-  ///   - Parameters:
-  ///      - collectionView: The collection view using the layout.
-  ///      - collectionViewLayout: The layout requesting the information.
-  ///      - indexPath: The index path of the item.
-  ///
-  ///   - Returns: The estimate height of the specified item.
-  func collectionView(
-    _ collectionView: UICollectionView,
-    layout collectionViewLayout: UICollectionViewLayout,
-    estimateHeightFor indexPath: IndexPath)
-    -> CGFloat
-
   ///   Asks the delegate for the visibility mode of the header in the specified section.
   ///
   ///   - Parameters:
@@ -302,17 +288,6 @@ public protocol UICollectionViewDelegateMagazineLayout: UICollectionViewDelegate
     finalLayoutAttributesForRemovedBackgroundInSectionAtIndex index: Int,
     byModifying finalLayoutAttributes: UICollectionViewLayoutAttributes)
 
-}
-
-// MARK: - Default estimate height
-public extension UICollectionViewDelegateMagazineLayout {
-  func collectionView(
-    _ collectionView: UICollectionView,
-    layout collectionViewLayout: UICollectionViewLayout,
-    estimateHeightFor indexPath: IndexPath)
-    -> CGFloat {
-      return MagazineLayout.Default.ItemHeight
-  }
 }
 
 // MARK: Default Insert Animations


### PR DESCRIPTION
## Details

Add estimatedHeight argument to MagazineLayoutItemSizeMode dynamic

## Related Issue
https://github.com/airbnb/MagazineLayout/issues/56

## Motivation and Context

Resolve the collection view jerking after reload data

## How Has This Been Tested
Implement the collection view contains multi item with dynamic height mode. Scroll collection view to bottom and reload data
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
