### PR TITLE
Bk/add vertical layout direction target content offset

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=15.2,name=iPhone 12']
+        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=16.2,name=iPhone 14']
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: xcodebuild clean build -scheme MagazineLayout
     - name: Run tests
-      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 8,OS=15.2"
+      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 14,OS=16.2"
 

--- a/MagazineLayout.podspec
+++ b/MagazineLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MagazineLayout'
-  s.version  = '1.6.11'
+  s.version  = '1.7.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A collection view layout that can display items in a grid and list arrangement.'
   s.homepage = 'https://github.com/airbnb/MagazineLayout'

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		FD4DFF0A21B0D182001F46CE /* MagazineLayoutCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4DFF0921B0D181001F46CE /* MagazineLayoutCollectionReusableView.swift */; };
 		FDABC2562B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDABC2552B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift */; };
 		FDABC2582B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDABC2572B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift */; };
+		FDE08E162B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE08E152B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift */; };
 		FDF6E15B21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF6E15A21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift */; };
 /* End PBXBuildFile section */
 
@@ -98,6 +99,7 @@
 		FD69EA0F21BA01E6001E0650 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FDABC2552B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutVerticalLayoutDirection.swift; sourceTree = "<group>"; };
 		FDABC2572B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetContentOffsetAnchor.swift; sourceTree = "<group>"; };
+		FDE08E152B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetContentOffsetAnchorTests.swift; sourceTree = "<group>"; };
 		FDF6E15A21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionViewLayoutAttributes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -146,6 +148,7 @@
 			children = (
 				FD23F5F021AF4A1B00AA78D4 /* Info.plist */,
 				93A1C00C21ACED0100DED67D /* ModelStateInitiallSetUpTests.swift */,
+				FDE08E152B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift */,
 				93A1C00A21ACED0100DED67D /* ModelStateEmptySectionLayoutTests.swift */,
 				93A1C00D21ACED0100DED67D /* ModelStateLayoutTests.swift */,
 				93A1C01021ACED0100DED67D /* ModelStateUpdateTests.swift */,
@@ -377,6 +380,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FDE08E162B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift in Sources */,
 				93A1C04B21ACED1100DED67D /* ModelStateInitiallSetUpTests.swift in Sources */,
 				9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */,
 				93A1C04C21ACED1100DED67D /* ModelStateLayoutTests.swift in Sources */,

--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		FD244FEF28B41F9900046C0D /* UITraitCollection+DisplayScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD244FEE28B41F9900046C0D /* UITraitCollection+DisplayScale.swift */; };
 		FD4DFF0821B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4DFF0721B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift */; };
 		FD4DFF0A21B0D182001F46CE /* MagazineLayoutCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4DFF0921B0D181001F46CE /* MagazineLayoutCollectionReusableView.swift */; };
+		FDABC2562B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDABC2552B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift */; };
+		FDABC2582B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDABC2572B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift */; };
 		FDF6E15B21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF6E15A21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift */; };
 /* End PBXBuildFile section */
 
@@ -94,6 +96,8 @@
 		FD4DFF0721B0C737001F46CE /* MagazineLayoutCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionViewCell.swift; sourceTree = "<group>"; };
 		FD4DFF0921B0D181001F46CE /* MagazineLayoutCollectionReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionReusableView.swift; sourceTree = "<group>"; };
 		FD69EA0F21BA01E6001E0650 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FDABC2552B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutVerticalLayoutDirection.swift; sourceTree = "<group>"; };
+		FDABC2572B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetContentOffsetAnchor.swift; sourceTree = "<group>"; };
 		FDF6E15A21B0B7870092775D /* MagazineLayoutCollectionViewLayoutAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLayoutCollectionViewLayoutAttributes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -182,6 +186,7 @@
 				FCAC642522085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift */,
 				93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */,
 				93A1C01621ACED0100DED67D /* MagazineLayoutBackgroundVisibilityMode.swift */,
+				FDABC2552B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift */,
 				93A1C01721ACED0100DED67D /* MagazineLayout+SupplementaryViewKinds.swift */,
 				93A1C02021ACED0100DED67D /* MagazineLayout+Default.swift */,
 			);
@@ -212,6 +217,7 @@
 				93A1C02521ACED0100DED67D /* ElementLocationFramePairs.swift */,
 				939846292296864200E442DA /* RowOffsetTracker.swift */,
 				93540AAF282E25D90008BD6F /* ScreenPixelAlignment.swift */,
+				FDABC2572B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift */,
 				FD244FEE28B41F9900046C0D /* UITraitCollection+DisplayScale.swift */,
 			);
 			path = Types;
@@ -357,7 +363,9 @@
 				93A1C03F21ACED0100DED67D /* MagazineLayoutSectionMetrics.swift in Sources */,
 				93A1C03A21ACED0100DED67D /* MagazineLayout.swift in Sources */,
 				FD244FEF28B41F9900046C0D /* UITraitCollection+DisplayScale.swift in Sources */,
+				FDABC2582B23D0A000C9B8EF /* TargetContentOffsetAnchor.swift in Sources */,
 				93A1C04021ACED0100DED67D /* CollectionViewUpdateItem.swift in Sources */,
+				FDABC2562B23CCF700C9B8EF /* MagazineLayoutVerticalLayoutDirection.swift in Sources */,
 				FCAC642622085AF100973F4C /* MagazineLayoutHeaderVisibilityMode.swift in Sources */,
 				93540AB0282E25D90008BD6F /* ScreenPixelAlignment.swift in Sources */,
 				93A1C03B21ACED0100DED67D /* MagazineLayoutInvalidationContext.swift in Sources */,

--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -17,6 +17,8 @@ import UIKit
 
 // MARK: - TargetContentOffsetAnchor
 
+/// An internal type for calculating the target content offset for various state of the collection view. Various anchors are possible, each
+/// changing how the collection view prioritizes keeping certain items visible in target content offset calculations.
 enum TargetContentOffsetAnchor: Equatable {
   case top
   case bottom

--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -1,0 +1,103 @@
+// Created by bryankeller on 12/8/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+// MARK: - TargetContentOffsetAnchor
+
+enum TargetContentOffsetAnchor: Equatable {
+  case top
+  case bottom
+  case topItem(id: String, distanceFromTop: CGFloat)
+  case bottomItem(id: String, distanceFromBottom: CGFloat)
+
+  static func targetContentOffsetAnchor(
+    verticalLayoutDirection: MagazineLayoutVerticalLayoutDirection,
+    topInset: CGFloat,
+    bottomInset: CGFloat,
+    bounds: CGRect,
+    contentHeight: CGFloat,
+    firstVisibleItemID: String,
+    lastVisibleItemID: String,
+    firstVisibleItemFrame: CGRect,
+    lastVisibleItemFrame: CGRect)
+    -> Self
+  {
+    let position: Position
+    if bounds.minY <= -topInset {
+      position = .atTop
+    } else if bounds.minY >= contentHeight + bottomInset - bounds.height {
+      position = .atBottom
+    } else {
+      position = .inMiddle
+    }
+
+    switch verticalLayoutDirection {
+    case .topToBottom:
+      switch position {
+      case .atTop:
+        return .top
+      case .inMiddle, .atBottom:
+        let distanceFromTop = firstVisibleItemFrame.minY - (bounds.minY + topInset)
+        return .topItem(id: firstVisibleItemID, distanceFromTop: distanceFromTop)
+      }
+    case .bottomToTop:
+      switch position {
+      case .atTop, .inMiddle:
+        let distanceFromBottom = lastVisibleItemFrame.maxY - (bounds.maxY - bottomInset)
+        return .bottomItem(id: lastVisibleItemID, distanceFromBottom: distanceFromBottom)
+      case .atBottom:
+        return .bottom
+      }
+    }
+  }
+
+  func yOffset(
+    topInset: CGFloat,
+    bottomInset: CGFloat,
+    bounds: CGRect,
+    contentHeight: CGFloat,
+    indexPathForItemID: (_ id: String) -> IndexPath?,
+    frameForItemAtIndexPath: (_ indexPath: IndexPath) -> CGRect)
+    -> CGFloat
+  {
+    switch self {
+    case .top:
+      return -topInset
+
+    case .bottom:
+      return contentHeight - bounds.height + bottomInset
+
+    case .topItem(let id, let distanceFromTop):
+      guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
+      let itemFrame = frameForItemAtIndexPath(indexPath)
+      return itemFrame.minY - topInset - distanceFromTop
+
+    case .bottomItem(let id, let distanceFromBottom):
+      guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
+      let itemFrame = frameForItemAtIndexPath(indexPath)
+      return itemFrame.maxY - bounds.height + bottomInset - distanceFromBottom
+    }
+  }
+
+}
+
+// MARK: - Position
+
+private enum Position {
+  case atTop
+  case inMiddle
+  case atBottom
+}

--- a/MagazineLayout/Public/Types/MagazineLayoutVerticalLayoutDirection.swift
+++ b/MagazineLayout/Public/Types/MagazineLayoutVerticalLayoutDirection.swift
@@ -1,0 +1,34 @@
+// Created by bryankeller on 12/8/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The vertical layout direction of items in the collection view. This property changes the behavior of scroll-position-preservation when
+/// performing batch updates or when the collection view's bounds changes.
+public enum MagazineLayoutVerticalLayoutDirection {
+
+  /// The vertical layout direction of items goes from top to bottom. Items inserted at the top push content down. When scrolled to the
+  /// top, inserted items at the top will be visible without scrolling. On bounds change (like device rotation or window size change), the
+  /// topmost visible item will remain visible while items at the bottom may change their position in relation to the bottom edge.
+  ///
+  /// Using this layout direction is essentially the default layout direction of all collection views.
+  case topToBottom
+
+  /// The vertical layout direction of items goes from bottom to top. Items inserted at the bottom push content up. When scrolled to the
+  /// bottom, inserted items at the bottom will be visible without scrolling. On bounds change (like device rotation or window size
+  /// change), the bottommost visible item will remain visible while items at the top may change their position in relation to the top
+  /// edge.
+  ///
+  ///  You might consider using this layout direction when building a message thread UI.
+  case bottomToTop
+}

--- a/Tests/TargetContentOffsetAnchorTests.swift
+++ b/Tests/TargetContentOffsetAnchorTests.swift
@@ -1,0 +1,186 @@
+// Created by bryankeller on 12/15/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import MagazineLayout
+
+final class TargetContentOffsetAnchorTests: XCTestCase {
+
+  // MARK: To-to-Bottom Anchor Tests
+
+  func testAnchor_TopToBottom_ScrolledToTop() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .topToBottom,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "0",
+      lastVisibleItemID: "4",
+      firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 290, width: 300, height: 20))
+    XCTAssert(anchor == .top)
+  }
+
+  func testAnchor_TopToBottom_ScrolledToMiddle() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .topToBottom,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "2",
+      lastVisibleItemID: "6",
+      firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
+    XCTAssert(anchor == .topItem(id: "2", distanceFromTop: 10))
+  }
+
+  func testAnchor_TopToBottom_ScrolledToBottom() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .topToBottom,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "6",
+      lastVisibleItemID: "10",
+      firstVisibleItemFrame: CGRect(x: 0, y: 1700, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 1950, width: 300, height: 20))
+    XCTAssert(anchor == .topItem(id: "6", distanceFromTop: 20))
+  }
+
+  // MARK: Bottom-to-Top Anchor Tests
+
+  func testAnchor_BottomToTop_ScrolledToTop() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .bottomToTop,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "0",
+      lastVisibleItemID: "4",
+      firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 290, width: 300, height: 20))
+    XCTAssert(anchor == .bottomItem(id: "4", distanceFromBottom: -10))
+  }
+
+  func testAnchor_BottomToTop_ScrolledToMiddle() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .bottomToTop,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "2",
+      lastVisibleItemID: "6",
+      firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
+    XCTAssert(anchor == .bottomItem(id: "6", distanceFromBottom: -50))
+  }
+
+  func testAnchor_BottomToTop_ScrolledToBottom() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .bottomToTop,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
+      contentHeight: 2000,
+      firstVisibleItemID: "6",
+      lastVisibleItemID: "10",
+      firstVisibleItemFrame: CGRect(x: 0, y: 1700, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 1950, width: 300, height: 20))
+    XCTAssert(anchor == .bottom)
+  }
+
+  // MARK: To-to-Bottom Target Content Offset Tests
+
+  func testOffset_TopToBottom_ScrolledToTop() {
+    let anchor = TargetContentOffsetAnchor.top
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 0, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 0, width: 300, height: 20) })
+    XCTAssert(offset == -50)
+  }
+
+  func testOffset_TopToBottom_ScrolledToMiddle() {
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 2, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 560, width: 300, height: 20) })
+    XCTAssert(offset == 500)
+  }
+
+  func testOffset_TopToBottom_ScrolledToBottom() {
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 6, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 1700, width: 300, height: 20) })
+    XCTAssert(offset == 1640)
+  }
+
+  // MARK: Bottom-to-Top Target Content Offset Tests
+
+  func testOffset_BottomToTop_ScrolledToTop() {
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "4", distanceFromBottom: -10)
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 4, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 290, width: 300, height: 20) })
+    XCTAssert(offset == -50)
+  }
+
+  func testOffset_BottomToTop_ScrolledToMiddle() {
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "6", distanceFromBottom: -50)
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 6, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 800, width: 300, height: 20) })
+    XCTAssert(offset == 500)
+  }
+
+  func testOffset_BottomToTop_ScrolledToBottom() {
+    let anchor = TargetContentOffsetAnchor.bottom
+    let offset = anchor.yOffset(
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
+      contentHeight: 2000,
+      indexPathForItemID: { _ in IndexPath(item: 10, section: 0) },
+      frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 1950, width: 300, height: 20) })
+    XCTAssert(offset == 1630)
+  }
+
+}


### PR DESCRIPTION
## Details

This PR refactors how `MagazineLayout` attempts to maintain the scroll position when batch updates occur and when the bounds changes (on device rotate, for example). A new configuration parameter has been added to control the vertical layout direction.

```swift
/// The vertical layout direction of items in the collection view. This property changes the behavior of scroll-position-preservation when
/// performing batch updates or when the collection view's bounds changes.
public enum MagazineLayoutVerticalLayoutDirection {

  /// The vertical layout direction of items goes from top to bottom. Items inserted at the top push content down. When scrolled to the
  /// top, inserted items at the top will be visible without scrolling. On bounds change (like device rotation or window size change), the
  /// topmost visible item will remain visible while items at the bottom may change their position in relation to the bottom edge.
  ///
  /// Using this layout direction is essentially the default layout direction of all collection views.
  case topToBottom

  /// The vertical layout direction of items goes from bottom to top. Items inserted at the bottom push content up. When scrolled to the
  /// bottom, inserted items at the bottom will be visible without scrolling. On bounds change (like device rotation or window size
  /// change), the bottommost visible item will remain visible while items at the top may change their position in relation to the top
  /// edge.
  ///
  ///  You might consider using this layout direction when building a message thread UI.
  case bottomToTop
}
```

#### Top to bottom behavior

https://github.com/airbnb/MagazineLayout/assets/746571/cfec97e4-d4d8-4cb7-a185-2649a20f5df2

#### Bottom to top behavior

https://github.com/airbnb/MagazineLayout/assets/746571/8bdaf680-37e6-4d88-9b9c-b6057f4faea5


## Related Issue

N/A

## Motivation and Context

Support better scroll position behavior for message thread UIs

## How Has This Been Tested

Unit tests, example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
