### PR TITLE
Bk/target content offset improvements

### DIFF
--- a/MagazineLayout/LayoutCore/Types/ElementLocation.swift
+++ b/MagazineLayout/LayoutCore/Types/ElementLocation.swift
@@ -52,3 +52,14 @@ struct ElementLocation: Hashable {
   }
 
 }
+
+// MARK: Comparable
+
+extension ElementLocation: Comparable {
+
+  static func < (lhs: ElementLocation, rhs: ElementLocation) -> Bool {
+    lhs.sectionIndex < rhs.sectionIndex
+      || (lhs.sectionIndex == rhs.sectionIndex && lhs.elementIndex < rhs.elementIndex)
+  }
+
+}

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -1245,6 +1245,7 @@ public final class MagazineLayout: UICollectionViewLayout {
     for itemLocationFramePair in modelState.itemLocationFramePairs(forItemsIn: bounds) {
       visibleItemLocationFramePairs.append(itemLocationFramePair)
     }
+    visibleItemLocationFramePairs.sort { $0.elementLocation < $1.elementLocation }
 
     let firstVisibleItemLocationFramePair = visibleItemLocationFramePairs.first {
       $0.frame.minY >= bounds.minY + topInset

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -99,13 +99,6 @@ public final class MagazineLayout: UICollectionViewLayout {
   override public func prepare() {
     super.prepare()
 
-    // Save the most recent content inset. We read this later in `invalidateLayout:`. Unlike the
-    // bounds and content size, the content insets are updated _before_ `invalidateLayout` is
-    // called, leaving us no choice other than tracking it separately here.
-    lastContentInset = contentInset
-
-    guard !prepareActions.isEmpty else { return }
-
     // Save the previous collection view width if necessary
     if prepareActions.contains(.cachePreviousWidth) {
       cachedCollectionViewWidth = currentCollectionView.bounds.width
@@ -255,6 +248,9 @@ public final class MagazineLayout: UICollectionViewLayout {
     modelState.applyUpdates(updates)
     hasDataSourceCountInvalidationBeforeReceivingUpdateItems = false
 
+    lastSizedElementMinY = nil
+    lastSizedElementPreferredHeight = nil
+
     super.prepare(forCollectionViewUpdates: updateItems)
   }
 
@@ -266,7 +262,14 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     targetContentOffsetAnchor = nil
     preInvalidationContentSize = nil
-    preInvalidationContentInset = nil
+
+    if let stagedContentOffsetAdjustment {
+      let context = MagazineLayoutInvalidationContext()
+      context.invalidateLayoutMetrics = false
+      context.contentOffsetAdjustment = stagedContentOffsetAdjustment
+      invalidateLayout(with: context)
+    }
+    stagedContentOffsetAdjustment = nil
 
     super.finalizeCollectionViewUpdates()
   }
@@ -276,15 +279,19 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     targetContentOffsetAnchor = targetContentOffsetAnchor(
       bounds: oldBounds,
-      contentHeight: preInvalidationContentSize?.height ?? collectionViewContentSize.height,
-      topInset: preInvalidationContentInset?.top ?? contentInset.top,
-      bottomInset: preInvalidationContentInset?.bottom ?? contentInset.bottom)
+      contentHeight: preInvalidationContentSize?.height ?? currentCollectionView.contentSize.height,
+      // There doesn't seem to be a reliable way to get the correct content insets here. We can try
+      // track them in invalidateLayout or prepare, but then there are edge cases where we need to
+      // track multiple past inset values. It's a huge mess, and I don't think it's worth solving.
+      // The downside is that if your insets change on rotation, you won't always land in the exact
+      // correct spot if you're in the middle of the content. Being at the top or bottom works fine.
+      topInset: 0,
+      bottomInset: 0)
   }
 
   override public func finalizeAnimatedBoundsChange() {
     targetContentOffsetAnchor = nil
     preInvalidationContentSize = nil
-    preInvalidationContentInset = nil
 
     super.finalizeAnimatedBoundsChange()
   }
@@ -665,6 +672,8 @@ public final class MagazineLayout: UICollectionViewLayout {
     withOriginalAttributes originalAttributes: UICollectionViewLayoutAttributes)
     -> UICollectionViewLayoutInvalidationContext
   {
+    let originalAttributes = originalAttributes.copy() as! UICollectionViewLayoutAttributes
+
     switch preferredAttributes.representedElementCategory {
     case .cell:
       modelState.updateItemHeight(
@@ -715,29 +724,60 @@ public final class MagazineLayout: UICollectionViewLayout {
       forPreferredLayoutAttributes: preferredAttributes,
       withOriginalAttributes: originalAttributes) as! MagazineLayoutInvalidationContext
 
-    // If layout information is discarded above our current scroll position (on rotation, for
-    // example), we need to compensate for preferred size changes to items as we're scrolling up,
-    // otherwise, the collection view will appear to jump each time an element is sized.
-    // Since size adjustments can occur for multiple items in the same soon-to-be-visible row, we
-    // need to account for this by considering the preferred height for previously sized elements in
-    // the same row so that we only adjust the content offset by the exact amount needed to create
-    // smooth scrolling.
     let isScrolling = currentCollectionView.isDragging || currentCollectionView.isDecelerating
-    let isSizingElementAboveTopEdge = originalAttributes.frame.minY < currentCollectionView.contentOffset.y
+    let top = currentCollectionView.bounds.minY + contentInset.top
+    let bottom = currentCollectionView.bounds.maxY
+    let isSizingElementAboveTopEdge = originalAttributes.frame.minY < top
+    let isSizingElementBelowBottomEdge = originalAttributes.frame.minY > bottom
 
-    if isScrolling && isSizingElementAboveTopEdge {
+    let contentOffsetAdjustment: CGPoint
+    if verticalLayoutDirection == .topToBottom, isSizingElementAboveTopEdge {
+      // If layout information is discarded above our current scroll position (on rotation, for
+      // example), we need to compensate for preferred size changes to items as we're scrolling up,
+      // otherwise, the collection view will appear to jump each time an element is sized.
+      // Since size adjustments can occur for multiple items in the same soon-to-be-visible row, we
+      // need to account for this by considering the preferred height for previously sized elements
+      // in the same row so that we only adjust the content offset by the exact amount needed to
+      // create smooth scrolling.
       let isSameRowAsLastSizedElement = lastSizedElementMinY?.isEqual(
         to: currentElementY,
         threshold: 1 / scale)
         ?? false
+
       if isSameRowAsLastSizedElement {
         let lastSizedElementPreferredHeight = self.lastSizedElementPreferredHeight ?? 0
         if preferredAttributes.size.height > lastSizedElementPreferredHeight {
-          context.contentOffsetAdjustment.y = preferredAttributes.size.height - lastSizedElementPreferredHeight
+          contentOffsetAdjustment = CGPoint(
+            x: 0,
+            y: preferredAttributes.size.height - lastSizedElementPreferredHeight)
+        } else {
+          contentOffsetAdjustment = .zero
         }
       } else {
-        context.contentOffsetAdjustment.y = preferredAttributes.size.height - originalAttributes.size.height
+        contentOffsetAdjustment = CGPoint(
+          x: 0,
+          y: preferredAttributes.size.height - originalAttributes.size.height)
       }
+    } else if
+      verticalLayoutDirection == .bottomToTop,
+      !isSizingElementBelowBottomEdge,
+      modelState.isPerformingBatchUpdates
+    {
+      contentOffsetAdjustment = CGPoint(
+        x: 0,
+        y: preferredAttributes.size.height - originalAttributes.size.height)
+    } else {
+      contentOffsetAdjustment = .zero
+    }
+
+    if modelState.isPerformingBatchUpdates {
+      // If we're in the middle of a batch update, we need to adjust our content offset. Doing it
+      // here in the middle of a batch update gets ignored for some reason. Instead, we delay
+      // slightly and do it in `finalizeCollectionViewUpdates`.
+      // This needs to be set in `finalizeCollectionViewUpdates`, otherwise it doesn't get applied.
+      stagedContentOffsetAdjustment = contentOffsetAdjustment
+    } else if isScrolling {
+      context.contentOffsetAdjustment = contentOffsetAdjustment
     }
 
     lastSizedElementMinY = currentElementY
@@ -753,11 +793,6 @@ public final class MagazineLayout: UICollectionViewLayout {
       assertionFailure("`context` must be an instance of `MagazineLayoutInvalidationContext`")
       return
     }
-
-    if collectionViewContentSize.width > 0, collectionViewContentSize.height > 0 {
-      preInvalidationContentSize = preInvalidationContentSize ?? collectionViewContentSize
-    }
-    preInvalidationContentInset = preInvalidationContentInset ?? lastContentInset ?? contentInset
 
     let shouldInvalidateLayoutMetrics = !context.invalidateEverything &&
       !context.invalidateDataSourceCounts
@@ -829,10 +864,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   private let _flipsHorizontallyInOppositeLayoutDirection: Bool
   private let verticalLayoutDirection: MagazineLayoutVerticalLayoutDirection
 
-  private var lastContentInset: UIEdgeInsets?
   private var cachedCollectionViewWidth: CGFloat?
-  private var preInvalidationContentSize: CGSize?
-  private var preInvalidationContentInset: UIEdgeInsets?
 
   // These properties are used to prevent scroll jumpiness due to self-sizing after rotation; see
   // comment in `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)` for more
@@ -870,6 +902,8 @@ public final class MagazineLayout: UICollectionViewLayout {
 
   private var isPerformingAnimatedBoundsChange = false
   private var targetContentOffsetAnchor: TargetContentOffsetAnchor?
+  private var preInvalidationContentSize: CGSize?
+  private var stagedContentOffsetAdjustment: CGPoint?
 
   // Used to provide the model state with the current visible bounds for the sole purpose of
   // supporting pinned headers and footers.
@@ -1241,18 +1275,15 @@ public final class MagazineLayout: UICollectionViewLayout {
     bottomInset: CGFloat)
     -> TargetContentOffsetAnchor?
   {
+    let insetBounds = bounds.inset(by: .init(top: topInset, left: 0, bottom: bottomInset, right: 0))
     var visibleItemLocationFramePairs = [ElementLocationFramePair]()
-    for itemLocationFramePair in modelState.itemLocationFramePairs(forItemsIn: bounds) {
+    for itemLocationFramePair in modelState.itemLocationFramePairs(forItemsIn: insetBounds) {
       visibleItemLocationFramePairs.append(itemLocationFramePair)
     }
     visibleItemLocationFramePairs.sort { $0.elementLocation < $1.elementLocation }
 
-    let firstVisibleItemLocationFramePair = visibleItemLocationFramePairs.first {
-      $0.frame.minY >= bounds.minY + topInset
-    }
-    let lastVisibleItemLocationFramePair = visibleItemLocationFramePairs.last {
-      $0.frame.maxY <= bounds.minY + bounds.height - bottomInset
-    }
+    let firstVisibleItemLocationFramePair = visibleItemLocationFramePairs.first
+    let lastVisibleItemLocationFramePair = visibleItemLocationFramePairs.last
 
     guard
       let firstVisibleItemLocationFramePair,
@@ -1273,6 +1304,7 @@ public final class MagazineLayout: UICollectionViewLayout {
       bottomInset: bottomInset,
       bounds: bounds,
       contentHeight: contentHeight,
+      scale: scale,
       firstVisibleItemID: firstVisibleItemID,
       lastVisibleItemID: lastVisibleItemID,
       firstVisibleItemFrame: firstVisibleItemLocationFramePair.frame,

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -265,6 +265,8 @@ public final class MagazineLayout: UICollectionViewLayout {
     supplementaryViewLayoutAttributesForPendingAnimations.removeAll()
 
     targetContentOffsetAnchor = nil
+    preInvalidationContentSize = nil
+    preInvalidationContentInset = nil
 
     super.finalizeCollectionViewUpdates()
   }
@@ -272,25 +274,17 @@ public final class MagazineLayout: UICollectionViewLayout {
   override public func prepare(forAnimatedBoundsChange oldBounds: CGRect) {
     super.prepare(forAnimatedBoundsChange: oldBounds)
 
-    let contentSize: CGSize
-    let contentInset: UIEdgeInsets
-    if let metricsSnapshot = metricsSnapshots.first(where: { $0.bounds == oldBounds }) {
-      contentSize = metricsSnapshot.contentSize
-      contentInset = metricsSnapshot.contentInset
-    } else {
-      contentSize = collectionViewContentSize
-      contentInset = self.contentInset
-    }
-
     targetContentOffsetAnchor = targetContentOffsetAnchor(
       bounds: oldBounds,
-      contentHeight: contentSize.height,
-      topInset: contentInset.top,
-      bottomInset: contentInset.bottom)
+      contentHeight: preInvalidationContentSize?.height ?? collectionViewContentSize.height,
+      topInset: preInvalidationContentInset?.top ?? contentInset.top,
+      bottomInset: preInvalidationContentInset?.bottom ?? contentInset.bottom)
   }
 
   override public func finalizeAnimatedBoundsChange() {
     targetContentOffsetAnchor = nil
+    preInvalidationContentSize = nil
+    preInvalidationContentInset = nil
 
     super.finalizeAnimatedBoundsChange()
   }
@@ -760,29 +754,10 @@ public final class MagazineLayout: UICollectionViewLayout {
       return
     }
 
-    // We need to save a few content size and content inset values for different bounds. This
-    // allows us to compute the correct target content offset in `prepareForAnimatedBoundsChange`.
-    // The root issue is that in the aforementioned function, we need a way to know what the content
-    // size and content inset _were_ for a given bounds value.
-    let metricsSnapshot = MetricsSnapshot(
-      bounds: currentCollectionView.bounds,
-      contentSize: collectionViewContentSize,
-      contentInset: lastContentInset ?? contentInset)
-
-    // Replace existing snapshot if the bounds is the same
-    let indexOfExistingMetricsSnapshot = metricsSnapshots.firstIndex {
-      $0.bounds == metricsSnapshot.bounds
+    if collectionViewContentSize.width > 0, collectionViewContentSize.height > 0 {
+      preInvalidationContentSize = preInvalidationContentSize ?? collectionViewContentSize
     }
-    if let indexOfExistingMetricsSnapshot {
-      metricsSnapshots[indexOfExistingMetricsSnapshot] = metricsSnapshot
-    } else {
-      metricsSnapshots.append(metricsSnapshot)
-    }
-
-    // Limit to 3 snapshots
-    if metricsSnapshots.count > 3 {
-      metricsSnapshots.removeFirst()
-    }
+    preInvalidationContentInset = preInvalidationContentInset ?? lastContentInset ?? contentInset
 
     let shouldInvalidateLayoutMetrics = !context.invalidateEverything &&
       !context.invalidateDataSourceCounts
@@ -856,13 +831,8 @@ public final class MagazineLayout: UICollectionViewLayout {
 
   private var lastContentInset: UIEdgeInsets?
   private var cachedCollectionViewWidth: CGFloat?
-
-  private struct MetricsSnapshot {
-    let bounds: CGRect
-    let contentSize: CGSize
-    let contentInset: UIEdgeInsets
-  }
-  private var metricsSnapshots = [MetricsSnapshot]()
+  private var preInvalidationContentSize: CGSize?
+  private var preInvalidationContentInset: UIEdgeInsets?
 
   // These properties are used to prevent scroll jumpiness due to self-sizing after rotation; see
   // comment in `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)` for more

--- a/Tests/TargetContentOffsetAnchorTests.swift
+++ b/Tests/TargetContentOffsetAnchorTests.swift
@@ -28,6 +28,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "0",
       lastVisibleItemID: "4",
       firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
@@ -42,11 +43,12 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "2",
       lastVisibleItemID: "6",
       firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
-    XCTAssert(anchor == .topItem(id: "2", distanceFromTop: 10))
+    XCTAssert(anchor == .topItem(id: "2", itemEdge: .top, distanceFromTop: 10))
   }
 
   func testAnchor_TopToBottom_ScrolledToBottom() throws {
@@ -56,11 +58,12 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "6",
       lastVisibleItemID: "10",
       firstVisibleItemFrame: CGRect(x: 0, y: 1700, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 1950, width: 300, height: 20))
-    XCTAssert(anchor == .topItem(id: "6", distanceFromTop: 20))
+    XCTAssert(anchor == .topItem(id: "6", itemEdge: .top, distanceFromTop: 20))
   }
 
   // MARK: Bottom-to-Top Anchor Tests
@@ -72,11 +75,12 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "0",
       lastVisibleItemID: "4",
       firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 290, width: 300, height: 20))
-    XCTAssert(anchor == .bottomItem(id: "4", distanceFromBottom: -10))
+    XCTAssert(anchor == .bottomItem(id: "4", itemEdge: .bottom, distanceFromBottom: -10))
   }
 
   func testAnchor_BottomToTop_ScrolledToMiddle() throws {
@@ -86,11 +90,12 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: 500, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "2",
       lastVisibleItemID: "6",
       firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
-    XCTAssert(anchor == .bottomItem(id: "6", distanceFromBottom: -50))
+    XCTAssert(anchor == .bottomItem(id: "6", itemEdge: .bottom, distanceFromBottom: -50))
   }
 
   func testAnchor_BottomToTop_ScrolledToBottom() throws {
@@ -100,6 +105,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       bottomInset: 30,
       bounds: CGRect(x: 0, y: 1630, width: 300, height: 400),
       contentHeight: 2000,
+      scale: 1,
       firstVisibleItemID: "6",
       lastVisibleItemID: "10",
       firstVisibleItemFrame: CGRect(x: 0, y: 1700, width: 300, height: 20),
@@ -122,7 +128,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_TopToBottom_ScrolledToMiddle() {
-    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", itemEdge: .top, distanceFromTop: 10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -134,7 +140,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_TopToBottom_ScrolledToBottom() {
-    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", itemEdge: .top, distanceFromTop: 10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -148,7 +154,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   // MARK: Bottom-to-Top Target Content Offset Tests
 
   func testOffset_BottomToTop_ScrolledToTop() {
-    let anchor = TargetContentOffsetAnchor.bottomItem(id: "4", distanceFromBottom: -10)
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "4", itemEdge: .bottom, distanceFromBottom: -10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -160,7 +166,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_BottomToTop_ScrolledToMiddle() {
-    let anchor = TargetContentOffsetAnchor.bottomItem(id: "6", distanceFromBottom: -50)
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "6", itemEdge: .bottom, distanceFromBottom: -50)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,


### PR DESCRIPTION
## Details

This further improves our scroll position preservation logic. I've gone down a funny rabbit hole trying to solve this, discovering https://github.com/ekazaev/ChatLayout and the related blog post https://itnext.io/my-covid-19-lockdown-project-or-how-i-started-to-dig-into-a-custom-uicollectionviewlayout-to-get-a-d053e1ad3aa0 - this project referenced a ton of MagazineLayout code, but also took things a step further for scroll position preservation since it's a key requirement of a chat interface. This blog post has some solid information about the complications of using self-sizing cells with `targetContentOffset`.

The main benefit to this PR is that we now handle some self-sizing-cell edge cases that previously caused some jumps.

## Related Issue

N/A

## Motivation and Context

Improve scroll position preservation logic

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
