### PR TITLE
Fix edge case with target content offset

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -277,16 +277,18 @@ public final class MagazineLayout: UICollectionViewLayout {
   override public func prepare(forAnimatedBoundsChange oldBounds: CGRect) {
     super.prepare(forAnimatedBoundsChange: oldBounds)
 
-    targetContentOffsetAnchor = targetContentOffsetAnchor(
-      bounds: oldBounds,
-      contentHeight: preInvalidationContentSize?.height ?? currentCollectionView.contentSize.height,
-      // There doesn't seem to be a reliable way to get the correct content insets here. We can try
-      // track them in invalidateLayout or prepare, but then there are edge cases where we need to
-      // track multiple past inset values. It's a huge mess, and I don't think it's worth solving.
-      // The downside is that if your insets change on rotation, you won't always land in the exact
-      // correct spot if you're in the middle of the content. Being at the top or bottom works fine.
-      topInset: 0,
-      bottomInset: 0)
+    if currentCollectionView.bounds.size != oldBounds.size {
+      targetContentOffsetAnchor = targetContentOffsetAnchor(
+        bounds: oldBounds,
+        contentHeight: preInvalidationContentSize?.height ?? currentCollectionView.contentSize.height,
+        // There doesn't seem to be a reliable way to get the correct content insets here. We can try
+        // track them in invalidateLayout or prepare, but then there are edge cases where we need to
+        // track multiple past inset values. It's a huge mess, and I don't think it's worth solving.
+        // The downside is that if your insets change on rotation, you won't always land in the exact
+        // correct spot if you're in the middle of the content. Being at the top or bottom works fine.
+        topInset: 0,
+        bottomInset: 0)
+    }
   }
 
   override public func finalizeAnimatedBoundsChange() {


### PR DESCRIPTION
## Details

This is a follow-up to https://github.com/airbnb/MagazineLayout/pull/116 - I realized that we don't want to do target content offset logic whenever the bounds changes (it changes when the content offset changes). We only want to handle target content offset if the size changes.

## Related Issue

N/A

## Motivation and Context

Fixing edge cases

## How Has This Been Tested

Example app, Airbnb app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
