### PR TITLE
Fix more row-sizing edge cases

### DIFF
--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -102,22 +102,27 @@ enum TargetContentOffsetAnchor: Equatable {
     frameForItemAtIndexPath: (_ indexPath: IndexPath) -> CGRect)
     -> CGFloat
   {
+    let minYOffset = -topInset
+    let maxYOffset = max(contentHeight - bounds.height + bottomInset, minYOffset)
+
     switch self {
     case .top:
-      return -topInset
+      return minYOffset
 
     case .bottom:
-      return contentHeight - bounds.height + bottomInset
+      return maxYOffset
 
     case .topItem(let id, let itemEdge, let distanceFromTop):
       guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
       let itemFrame = frameForItemAtIndexPath(indexPath)
-      return itemFrame.value(for: itemEdge) - topInset - distanceFromTop
+      let proposedYOffset = itemFrame.value(for: itemEdge) - topInset - distanceFromTop
+      return min(max(proposedYOffset, minYOffset), maxYOffset) // Clamp between minYOffset...maxYOffset
 
     case .bottomItem(let id, let itemEdge, let distanceFromBottom):
       guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
       let itemFrame = frameForItemAtIndexPath(indexPath)
-      return itemFrame.value(for: itemEdge) - bounds.height + bottomInset - distanceFromBottom
+      let proposedYOffset = itemFrame.value(for: itemEdge) - bounds.height + bottomInset - distanceFromBottom
+      return min(max(proposedYOffset, minYOffset), maxYOffset) // Clamp between minYOffset...maxYOffset
     }
   }
 

--- a/Tests/TargetContentOffsetAnchorTests.swift
+++ b/Tests/TargetContentOffsetAnchorTests.swift
@@ -148,7 +148,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       contentHeight: 2000,
       indexPathForItemID: { _ in IndexPath(item: 6, section: 0) },
       frameForItemAtIndexPath: { _ in CGRect(x: 0, y: 1700, width: 300, height: 20) })
-    XCTAssert(offset == 1640)
+    XCTAssert(offset == 1630)
   }
 
   // MARK: Bottom-to-Top Target Content Offset Tests


### PR DESCRIPTION
## Details

This PR rethinks how we maintain the content offset when encountering a self-sizing cell. In the end, I ended up rewriting the old logic and replacing it with something that works for both the simple case and the more complex cases:

Case 1: "I'm scrolling up and encountering self-sizing cells above my current position" (this always worked with the old logic)
Case 2: "I'm inserting new self-sizing cells while simultaneously trying to maintain my content offset via the new target-content-offset system" (the old logic didn't work for this new case)

After several band-aid attempts, I decided to burn it all down and rethink things. I realized that we can solve both cases using the following approach:

1. Before applying a preferred height to our layout, figure out what our current target content offset anchor is (`top`, `bottom`, `topItem`, `bottomItem`)
2. Figure out what our content offset should be, given the target content offset anchor from step 1
3. Apply the preferred height to the layout
4. Figure out what our content offset should be now what we've actually applied the preferred height to the layout, still using the target content offset anchor from step 1
5. The difference in the content offset from step 2 and 4 is our content offset adjustment

## Related Issue

N/A

## Motivation and Context

Get this working correctly for all cases

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
