### PR TITLE
Fix target content offset edge case for small content

### DIFF
--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -40,10 +40,19 @@ enum TargetContentOffsetAnchor: Equatable {
   {
     let top = (-topInset).alignedToPixel(forScreenWithScale: scale)
     let bottom = (contentHeight + bottomInset - bounds.height).alignedToPixel(forScreenWithScale: scale)
+    let isAtTop = bounds.minY <= top
+    let isAtBottom = bounds.minY >= bottom
     let position: Position
-    if bounds.minY <= top {
+    if isAtTop, isAtBottom {
+      switch verticalLayoutDirection {
+      case .topToBottom: 
+        position = .atTop
+      case .bottomToTop: 
+        position = .atBottom
+      }
+    } else if isAtTop {
       position = .atTop
-    } else if bounds.minY >= bottom {
+    } else if isAtBottom {
       position = .atBottom
     } else {
       position = .inMiddle

--- a/Tests/TargetContentOffsetAnchorTests.swift
+++ b/Tests/TargetContentOffsetAnchorTests.swift
@@ -66,6 +66,21 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
     XCTAssert(anchor == .topItem(id: "6", itemEdge: .top, distanceFromTop: 20))
   }
 
+  func testAnchor_TopToBottom_SmallContentHeight() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .topToBottom,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 50,
+      scale: 1,
+      firstVisibleItemID: "0",
+      lastVisibleItemID: "1",
+      firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 30, width: 300, height: 20))
+    XCTAssert(anchor == .top)
+  }
+
   // MARK: Bottom-to-Top Anchor Tests
 
   func testAnchor_BottomToTop_ScrolledToTop() throws {
@@ -113,7 +128,22 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
     XCTAssert(anchor == .bottom)
   }
 
-  // MARK: To-to-Bottom Target Content Offset Tests
+  func testAnchor_BottomToTop_SmallContentHeight() throws {
+    let anchor = TargetContentOffsetAnchor.targetContentOffsetAnchor(
+      verticalLayoutDirection: .bottomToTop,
+      topInset: 50,
+      bottomInset: 30,
+      bounds: CGRect(x: 0, y: -50, width: 300, height: 400),
+      contentHeight: 50,
+      scale: 1,
+      firstVisibleItemID: "0",
+      lastVisibleItemID: "1",
+      firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
+      lastVisibleItemFrame: CGRect(x: 0, y: 30, width: 300, height: 20))
+    XCTAssert(anchor == .bottom)
+  }
+
+  // MARK: Top-to-Bottom Target Content Offset Tests
 
   func testOffset_TopToBottom_ScrolledToTop() {
     let anchor = TargetContentOffsetAnchor.top


### PR DESCRIPTION
## Details

This fixes an edge case with the target content offset anchor calculation. If the content is shorter than the visible bounds, that means we're simultaneously at our topmost offset and bottommost offset. In this scenario, the previous logic would always calculate a target content offset anchor of `.top`. The correct logic in this scenario should be:

- Anchor is `.top` if our `verticalLayoutDirection` is `.topToBottom`
- Anchor is `.bottom` if our `verticalLayoutDirection` is `.bottomToTop`

## Related Issue

Noticed a scenario where new messages don't push the content down when a thread is just getting started (short content height)

## Motivation and Context

Squashin bugs

## How Has This Been Tested

Example app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
