### PR TITLE
bottomToTop scrollOffset preservation

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -586,18 +586,17 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   override public func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-    // When using the topToBottom layout direction, we only want
-    // to invalidate the layout when the widths differ.
-    // When using the bottomToTop layout direction, we want to
-    // invalidate on any size change due to the requirement of
-    // needing to preserve scroll position from the bottom
-    let shouldInvalidateDueToSize = switch verticalLayoutDirection {
+    // When using the topToBottom layout direction, we only want to invalidate the layout when the
+    // widths differ. When using the bottomToTop layout direction, we want to invalidate on any
+    // size change due to the requirement of  needing to preserve scroll position from the bottom
+    var shouldInvalidateDueToSize = false
+    switch verticalLayoutDirection {
     case .topToBottom:
-      !currentCollectionView.bounds.size.width.isEqual(
+      shouldInvalidateDueToSize = !currentCollectionView.bounds.size.width.isEqual(
         to: newBounds.size.width,
         threshold: 1 / scale)
     case .bottomToTop:
-      !(currentCollectionView.bounds.size.width.isEqual(
+      shouldInvalidateDueToSize = !(currentCollectionView.bounds.size.width.isEqual(
         to: newBounds.size.width,
         threshold: 1 / scale) &&
       currentCollectionView.bounds.size.height.isEqual(
@@ -620,10 +619,12 @@ public final class MagazineLayout: UICollectionViewLayout {
       height: newBounds.height - currentCollectionView.bounds.height)
     invalidationContext.invalidateLayoutMetrics = false
 
-    // If our layout direction is bottom to top we want to
-    // adjust scroll position relative to the bottom
+    // If our layout direction is bottom to top we want to adjust scroll position relative to the
+    // bottom
     if case .bottomToTop = verticalLayoutDirection {
-      invalidationContext.contentOffsetAdjustment = CGPoint(x: 0.0, y: currentCollectionView.bounds.height - newBounds.height)
+      invalidationContext.contentOffsetAdjustment = CGPoint(
+        x: 0.0,
+        y: currentCollectionView.bounds.height - newBounds.height)
     }
 
     return invalidationContext

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -586,11 +586,26 @@ public final class MagazineLayout: UICollectionViewLayout {
   }
 
   override public func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-    let isSameWidth = collectionView?.bounds.size.width.isEqual(
-      to: newBounds.size.width,
-      threshold: 1 / scale)
-      ?? false
-    return !isSameWidth || hasPinnedHeaderOrFooter
+    // When using the topToBottom layout direction, we only want
+    // to invalidate the layout when the widths differ.
+    // When using the bottomToTop layout direction, we want to
+    // invalidate on any size change due to the requirement of
+    // needing to preserve scroll position from the bottom
+    let shouldInvalidateDueToSize = switch verticalLayoutDirection {
+    case .topToBottom:
+      !currentCollectionView.bounds.size.width.isEqual(
+        to: newBounds.size.width,
+        threshold: 1 / scale)
+    case .bottomToTop:
+      !(currentCollectionView.bounds.size.width.isEqual(
+        to: newBounds.size.width,
+        threshold: 1 / scale) &&
+      currentCollectionView.bounds.size.height.isEqual(
+        to: newBounds.size.height,
+        threshold: 1 / scale))
+    }
+
+    return shouldInvalidateDueToSize || hasPinnedHeaderOrFooter
   }
 
   override public func invalidationContext(
@@ -604,6 +619,12 @@ public final class MagazineLayout: UICollectionViewLayout {
       width: newBounds.width - currentCollectionView.bounds.width,
       height: newBounds.height - currentCollectionView.bounds.height)
     invalidationContext.invalidateLayoutMetrics = false
+
+    // If our layout direction is bottom to top we want to
+    // adjust scroll position relative to the bottom
+    if case .bottomToTop = verticalLayoutDirection {
+      invalidationContext.contentOffsetAdjustment = CGPoint(x: 0.0, y: currentCollectionView.bounds.height - newBounds.height)
+    }
 
     return invalidationContext
   }


### PR DESCRIPTION
## Details

When using the `bottomToTop` layoutDirection, we should preserve scroll position relative to the bottom of the collection view whenever we change bounds.

## Related Issue



## Motivation and Context



## How Has This Been Tested

Tested in the airbnb app

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
