### PR TITLE
Performance improvements during layout calculation

### DIFF
--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -608,7 +608,7 @@ final class ModelState {
   }
 
   func removeFooter(forSectionAtIndex sectionIndex: Int) {
-    if (currentSectionModels[sectionIndex].removeFooter()) {
+    if currentSectionModels[sectionIndex].removeFooter() {
       invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
       prepareElementLocationsForFlattenedIndices()
     }

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -593,11 +593,10 @@ final class ModelState {
   }
 
   func removeHeader(forSectionAtIndex sectionIndex: Int) {
-    currentSectionModels[sectionIndex].removeHeader()
-
-    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
-
-    prepareElementLocationsForFlattenedIndices()
+    if(currentSectionModels[sectionIndex].removeHeader()) {
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+      prepareElementLocationsForFlattenedIndices()
+    }
   }
 
   func setFooter(_ footerModel: FooterModel, forSectionAtIndex sectionIndex: Int) {
@@ -609,11 +608,10 @@ final class ModelState {
   }
 
   func removeFooter(forSectionAtIndex sectionIndex: Int) {
-    currentSectionModels[sectionIndex].removeFooter()
-
-    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
-
-    prepareElementLocationsForFlattenedIndices()
+    if (currentSectionModels[sectionIndex].removeFooter()) {
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+      prepareElementLocationsForFlattenedIndices()
+    }
   }
 
   func setBackground(
@@ -626,9 +624,9 @@ final class ModelState {
   }
 
   func removeBackground(forSectionAtIndex sectionIndex: Int) {
-    currentSectionModels[sectionIndex].removeBackground()
-
-    prepareElementLocationsForFlattenedIndices()
+    if(currentSectionModels[sectionIndex].removeBackground()) {
+      prepareElementLocationsForFlattenedIndices()
+    }
   }
 
   func setSections(_ sectionModels: [SectionModel]) {

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -593,7 +593,7 @@ final class ModelState {
   }
 
   func removeHeader(forSectionAtIndex sectionIndex: Int) {
-    if(currentSectionModels[sectionIndex].removeHeader()) {
+    if currentSectionModels[sectionIndex].removeHeader() {
       invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
       prepareElementLocationsForFlattenedIndices()
     }

--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -624,7 +624,7 @@ final class ModelState {
   }
 
   func removeBackground(forSectionAtIndex sectionIndex: Int) {
-    if(currentSectionModels[sectionIndex].removeBackground()) {
+    if currentSectionModels[sectionIndex].removeBackground() {
       prepareElementLocationsForFlattenedIndices()
     }
   }

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -247,20 +247,22 @@ struct SectionModel {
     }
   }
 
-  mutating func removeHeader() {
-    if let indexOfHeader = indexOfHeaderRow() {
-      updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfHeader)
+  mutating func removeHeader() -> Bool {
+    guard let indexOfHeader = indexOfHeaderRow() else {
+      return false
     }
-
+    updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfHeader)
     headerModel = nil
+    return true
   }
 
-  mutating func removeFooter() {
-    if let indexOfFooter = indexOfFooterRow() {
-      updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfFooter)
+  mutating func removeFooter() -> Bool {
+    guard let indexOfFooter = indexOfFooterRow() else {
+      return false
     }
-
+    updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: indexOfFooter)
     footerModel = nil
+    return true
   }
 
   mutating func updateItemHeight(toPreferredHeight preferredHeight: CGFloat, atIndex index: Int) {
@@ -334,9 +336,13 @@ struct SectionModel {
     // No need to invalidate since the background doesn't affect the layout.
   }
 
-  mutating func removeBackground() {
-    backgroundModel = nil
+  mutating func removeBackground() -> Bool {
+    guard backgroundModel != nil else {
+      return false
+    }
+    self.backgroundModel = nil
     // No need to invalidate since the background doesn't affect the layout.
+    return true
   }
 
   // MARK: Private


### PR DESCRIPTION
## Details

Both `invalidateSectionMaxYsCacheForSectionIndices` and `invalidateEntireSectionMaxYsCache` do linear passes. These are called on each section header, section footer and background. Leading to a lot of work being done with long lists.

This PR short circuits the work if we try to remove header, footers and backgrounds that don't exist.

A better option would be to run the calls above once per update vs per update item. That would require a bit more rework though.

## Related Issue


## Motivation and Context

I was working with long lists and was getting a significant amount of hangs.
This was before the change:
![](https://files.slack.com/files-pri/TTFSVLNMV-F06ME1ATKEK/screenshot_2024-03-04_at_1.04.54___pm.png)

This was after:
![](https://files.slack.com/files-pri/TTFSVLNMV-F06MRL9GTTP/screenshot_2024-03-04_at_1.05.16___pm.png)

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
Tested in the airbnb app.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
