### PR TITLE
Clear cached layout attributes if the data source counts change

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -808,6 +808,13 @@ public final class MagazineLayout: UICollectionViewLayout {
     hasDataSourceCountInvalidationBeforeReceivingUpdateItems = context.invalidateDataSourceCounts &&
       !context.invalidateEverything
 
+    if context.invalidateDataSourceCounts {
+      itemLayoutAttributes.removeAll()
+      headerLayoutAttributes.removeAll()
+      footerLayoutAttributes.removeAll()
+      backgroundLayoutAttributes.removeAll()
+    }
+
     super.invalidateLayout(with: context)
   }
 


### PR DESCRIPTION
## Details

I meant to include this with my last PR - this fixes an issue that causes off-screen cells coming into view due to a batch update to use incorrect layout attributes, causing them to have an incorrect size during the animation. In the video below, you can see that cell 0 is deleted, cell 1 animates in from above the top edge of the screen, and incorrectly reuses the cached layout attributes of cell 2 (new cell 1 after updates), which is a really tall cell.

https://github.com/airbnb/MagazineLayout/assets/746571/11d1003e-9557-43ad-a1a9-d6ce5a8570e3


## Related Issue

N/A

## Motivation and Context

Bug fix

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
