### PR TITLE
Refine top and bottom item anchor calculation

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,4 @@
-name: Swift
+name: CI
 
 on:
   push:
@@ -8,17 +8,14 @@ on:
 
 jobs:
   build:
-
-    runs-on: macos-latest
-
+    runs-on: macos-13
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=11.0,name=iPhone 8', 'platform=iOS Simulator,OS=16.2,name=iPhone 14']
-
+        xcode:
+        - '15.0' # Swift 5.9
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: xcodebuild clean build -scheme MagazineLayout
-    - name: Run tests
-      run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 14,OS=16.2"
-
+      - uses: actions/checkout@v4
+      - name: Build
+        run: xcodebuild clean build -scheme MagazineLayout -destination "generic/platform=iOS Simulator"
+      - name: Run tests
+        run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 14,OS=17.2"

--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -22,8 +22,8 @@ import UIKit
 enum TargetContentOffsetAnchor: Equatable {
   case top
   case bottom
-  case topItem(id: String, itemEdge: ItemEdge, distanceFromTop: CGFloat)
-  case bottomItem(id: String, itemEdge: ItemEdge, distanceFromBottom: CGFloat)
+  case topItem(id: String, distanceFromTop: CGFloat)
+  case bottomItem(id: String, distanceFromBottom: CGFloat)
 
   static func targetContentOffsetAnchor(
     verticalLayoutDirection: MagazineLayoutVerticalLayoutDirection,
@@ -65,37 +65,19 @@ enum TargetContentOffsetAnchor: Equatable {
         return .top
       case .inMiddle, .atBottom:
         let top = bounds.minY + topInset
-        let topDistanceFromTop = firstVisibleItemFrame.value(for: .top) - top
-        let bottomDistanceFromTop = firstVisibleItemFrame.value(for: .bottom) - top
-        if abs(topDistanceFromTop) < abs(bottomDistanceFromTop) {
-          return .topItem(
-            id: firstVisibleItemID,
-            itemEdge: .top,
-            distanceFromTop: topDistanceFromTop.alignedToPixel(forScreenWithScale: scale))
-        } else {
-          return .topItem(
-            id: firstVisibleItemID,
-            itemEdge: .bottom,
-            distanceFromTop: bottomDistanceFromTop.alignedToPixel(forScreenWithScale: scale))
-        }
+        let distanceFromTop = firstVisibleItemFrame.minY - top
+        return .topItem(
+          id: firstVisibleItemID,
+          distanceFromTop: distanceFromTop.alignedToPixel(forScreenWithScale: scale))
       }
     case .bottomToTop:
       switch position {
       case .atTop, .inMiddle:
         let bottom = bounds.maxY - bottomInset
-        let topDistanceFromBottom = lastVisibleItemFrame.value(for: .top) - bottom
-        let bottomDistanceFromBottom = lastVisibleItemFrame.value(for: .bottom) - bottom
-        if abs(topDistanceFromBottom) < abs(bottomDistanceFromBottom) {
-          return .bottomItem(
-            id: lastVisibleItemID,
-            itemEdge: .top,
-            distanceFromBottom: topDistanceFromBottom.alignedToPixel(forScreenWithScale: scale))
-        } else {
-          return .bottomItem(
-            id: lastVisibleItemID,
-            itemEdge: .bottom,
-            distanceFromBottom: bottomDistanceFromBottom.alignedToPixel(forScreenWithScale: scale))
-        }
+        let distanceFromBottom = lastVisibleItemFrame.maxY - bottom
+        return .bottomItem(
+          id: lastVisibleItemID,
+          distanceFromBottom: distanceFromBottom.alignedToPixel(forScreenWithScale: scale))
       case .atBottom:
         return .bottom
       }
@@ -121,39 +103,17 @@ enum TargetContentOffsetAnchor: Equatable {
     case .bottom:
       return maxYOffset
 
-    case .topItem(let id, let itemEdge, let distanceFromTop):
+    case .topItem(let id, let distanceFromTop):
       guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
       let itemFrame = frameForItemAtIndexPath(indexPath)
-      let proposedYOffset = itemFrame.value(for: itemEdge) - topInset - distanceFromTop
+      let proposedYOffset = itemFrame.minY - topInset - distanceFromTop
       return min(max(proposedYOffset, minYOffset), maxYOffset) // Clamp between minYOffset...maxYOffset
 
-    case .bottomItem(let id, let itemEdge, let distanceFromBottom):
+    case .bottomItem(let id, let distanceFromBottom):
       guard let indexPath = indexPathForItemID(id) else { return bounds.minY }
       let itemFrame = frameForItemAtIndexPath(indexPath)
-      let proposedYOffset = itemFrame.value(for: itemEdge) - bounds.height + bottomInset - distanceFromBottom
+      let proposedYOffset = itemFrame.maxY - bounds.height + bottomInset - distanceFromBottom
       return min(max(proposedYOffset, minYOffset), maxYOffset) // Clamp between minYOffset...maxYOffset
-    }
-  }
-
-}
-
-// MARK: ItemEdge
-
-enum ItemEdge {
-  case top
-  case bottom
-}
-
-// MARK: CGRect + Item Edge Value
-
-private extension CGRect {
-
-  func value(for itemEdge: ItemEdge) -> CGFloat {
-    switch itemEdge {
-    case .top:
-      return minY
-    case .bottom:
-      return maxY
     }
   }
 

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -1261,9 +1261,8 @@ public final class MagazineLayout: UICollectionViewLayout {
     bottomInset: CGFloat)
     -> TargetContentOffsetAnchor?
   {
-    let insetBounds = bounds.inset(by: .init(top: topInset, left: 0, bottom: bottomInset, right: 0))
     var visibleItemLocationFramePairs = [ElementLocationFramePair]()
-    for itemLocationFramePair in modelState.itemLocationFramePairs(forItemsIn: insetBounds) {
+    for itemLocationFramePair in modelState.itemLocationFramePairs(forItemsIn: bounds) {
       visibleItemLocationFramePairs.append(itemLocationFramePair)
     }
     visibleItemLocationFramePairs.sort { $0.elementLocation < $1.elementLocation }

--- a/Tests/TargetContentOffsetAnchorTests.swift
+++ b/Tests/TargetContentOffsetAnchorTests.swift
@@ -48,7 +48,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       lastVisibleItemID: "6",
       firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
-    XCTAssert(anchor == .topItem(id: "2", itemEdge: .top, distanceFromTop: 10))
+    XCTAssert(anchor == .topItem(id: "2", distanceFromTop: 10))
   }
 
   func testAnchor_TopToBottom_ScrolledToBottom() throws {
@@ -63,7 +63,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       lastVisibleItemID: "10",
       firstVisibleItemFrame: CGRect(x: 0, y: 1700, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 1950, width: 300, height: 20))
-    XCTAssert(anchor == .topItem(id: "6", itemEdge: .top, distanceFromTop: 20))
+    XCTAssert(anchor == .topItem(id: "6", distanceFromTop: 20))
   }
 
   func testAnchor_TopToBottom_SmallContentHeight() throws {
@@ -95,7 +95,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       lastVisibleItemID: "4",
       firstVisibleItemFrame: CGRect(x: 0, y: 0, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 290, width: 300, height: 20))
-    XCTAssert(anchor == .bottomItem(id: "4", itemEdge: .bottom, distanceFromBottom: -10))
+    XCTAssert(anchor == .bottomItem(id: "4", distanceFromBottom: -10))
   }
 
   func testAnchor_BottomToTop_ScrolledToMiddle() throws {
@@ -110,7 +110,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
       lastVisibleItemID: "6",
       firstVisibleItemFrame: CGRect(x: 0, y: 560, width: 300, height: 20),
       lastVisibleItemFrame: CGRect(x: 0, y: 800, width: 300, height: 20))
-    XCTAssert(anchor == .bottomItem(id: "6", itemEdge: .bottom, distanceFromBottom: -50))
+    XCTAssert(anchor == .bottomItem(id: "6", distanceFromBottom: -50))
   }
 
   func testAnchor_BottomToTop_ScrolledToBottom() throws {
@@ -158,7 +158,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_TopToBottom_ScrolledToMiddle() {
-    let anchor = TargetContentOffsetAnchor.topItem(id: "2", itemEdge: .top, distanceFromTop: 10)
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -170,7 +170,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_TopToBottom_ScrolledToBottom() {
-    let anchor = TargetContentOffsetAnchor.topItem(id: "2", itemEdge: .top, distanceFromTop: 10)
+    let anchor = TargetContentOffsetAnchor.topItem(id: "2", distanceFromTop: 10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -184,7 +184,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   // MARK: Bottom-to-Top Target Content Offset Tests
 
   func testOffset_BottomToTop_ScrolledToTop() {
-    let anchor = TargetContentOffsetAnchor.bottomItem(id: "4", itemEdge: .bottom, distanceFromBottom: -10)
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "4", distanceFromBottom: -10)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,
@@ -196,7 +196,7 @@ final class TargetContentOffsetAnchorTests: XCTestCase {
   }
 
   func testOffset_BottomToTop_ScrolledToMiddle() {
-    let anchor = TargetContentOffsetAnchor.bottomItem(id: "6", itemEdge: .bottom, distanceFromBottom: -50)
+    let anchor = TargetContentOffsetAnchor.bottomItem(id: "6", distanceFromBottom: -50)
     let offset = anchor.yOffset(
       topInset: 50,
       bottomInset: 30,


### PR DESCRIPTION
## Details

This refines our target content offset logic. Previously, we used the _closest_ edge of an item to be an anchor. For example, in a `topToBottom` layout, we would use the topmost item's top or bottom edge as the anchor for scroll position preservation, depending on which was closest to the top edge. This causes weird issues if the height of an item changes, since it will visually grow upward or downward depending on how close it is to the top of the screen.

I think a simpler and more predictable behavior is to simply always use the top edge of the topmost item as the anchor point. Similarly, for a `bottomToTop` layout, we'll always use the bottom edge of the bottommost item as the anchor point.

## Related Issue

N/A

## Motivation and Context

Some weird issues with voting on wish lists, since adding a vote changes the height of the cell. The direction the card grows after resizing changes depending on how close it is to the top edge.

https://github.com/airbnb/MagazineLayout/assets/746571/09f42034-12d0-4bab-ad48-0ae22aaf7915

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
