### PR TITLE
fix content offset adjustment for bounds changing

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -615,10 +615,13 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     // If our layout direction is bottom to top we want to adjust scroll position relative to the
     // bottom
-    if case .bottomToTop = verticalLayoutDirection {
+    if
+      case .bottomToTop = verticalLayoutDirection,
+       newBounds.maxY < currentCollectionView.contentSize.height + contentInset.bottom
+    {
       invalidationContext.contentOffsetAdjustment = CGPoint(
         x: 0.0,
-        y: max(currentCollectionView.bounds.height - newBounds.height + contentInset.bottom, 0))
+        y: currentCollectionView.bounds.maxY - newBounds.maxY)
     }
 
     return invalidationContext


### PR DESCRIPTION
## Details

For the bottomToTop layout, the y offset adjustment `max(currentCollectionView.bounds.height - newBounds.height + contentInset.bottom, 0)`  is not right. we should not involve the `contentInset.bottom`.
The iOS system will help adjust the yOffset when new bounds exceed the boundary. It means we should check 
`if newBounds.maxY < currentCollectionView.contentSize.height + contentInset.bottom` as well.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We are building an messaging screen for Airbnb and I find this issue causes the message cells jumping when typing indicator hide and show.

## How Has This Been Tested

I built a small sample to test this case.
Before this change: The cells move up every time the bounds changed.
After the change: The cells keep bottom spacing the same.

| Before | After |
| --- | --- |
| ![ezgif-1-b9833aa1ea](https://github.com/airbnb/MagazineLayout/assets/129608435/4cb81438-11fe-4aeb-883d-e499efc0c72b) | ![ezgif-1-99777f3cb7](https://github.com/airbnb/MagazineLayout/assets/129608435/4632d169-5f01-4b37-83ee-3be6fae893b3) |

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.