### PR TITLE
Fix section moves

### DIFF
--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -660,20 +660,27 @@ final class ModelState {
       switch update {
       case let .sectionReload(sectionIndex, newSection):
         sectionModelReloadIndexPairs.append((newSection, sectionIndex))
+
       case let .itemReload(itemIndexPath, newItem):
         itemModelReloadIndexPathPairs.append((newItem, itemIndexPath))
 
       case let .sectionDelete(sectionIndex):
         sectionIndicesToDelete.append(sectionIndex)
         self.sectionIndicesToDelete.insert(sectionIndex)
+
       case let .itemDelete(itemIndexPath):
         itemIndexPathsToDelete.append(itemIndexPath)
         self.itemIndexPathsToDelete.insert(itemIndexPath)
 
       case let .sectionMove(initialSectionIndex, finalSectionIndex):
         sectionIndicesToDelete.append(initialSectionIndex)
-        let sectionModelToMove = sectionModelsBeforeBatchUpdates[initialSectionIndex]
+        var sectionModelToMove = sectionModelsBeforeBatchUpdates[initialSectionIndex]
+        // Item moves are handled separately, so we need to clear out existing items
+        for itemIndex in (0..<sectionModelToMove.numberOfItems).reversed() {
+          sectionModelToMove.deleteItemModel(atIndex: itemIndex)
+        }
         sectionModelInsertIndexPairs.append((sectionModelToMove, finalSectionIndex))
+
       case let .itemMove(initialItemIndexPath, finalItemIndexPath):
         itemIndexPathsToDelete.append(initialItemIndexPath)
         let sectionContainingItemModelToMove = sectionModelsBeforeBatchUpdates[initialItemIndexPath.section]
@@ -684,6 +691,7 @@ final class ModelState {
       case let .sectionInsert(sectionIndex, newSection):
         sectionModelInsertIndexPairs.append((newSection, sectionIndex))
         sectionIndicesToInsert.insert(sectionIndex)
+
       case let .itemInsert(itemIndexPath, newItem):
         itemModelInsertIndexPathPairs.append((newItem, itemIndexPath))
         itemIndexPathsToInsert.insert(itemIndexPath)

--- a/Tests/ModelStateUpdateTests.swift
+++ b/Tests/ModelStateUpdateTests.swift
@@ -192,13 +192,18 @@ final class ModelStateUpdateTests: XCTestCase {
   func testSectionMoves() {
     let initialSections = ModelHelpers.basicSectionModels(
       numberOfSections: 3,
-      numberOfItemsPerSection: 0)
+      numberOfItemsPerSection: 2)
     modelState.setSections(initialSections)
 
     modelState.applyUpdates(
       [
         .sectionMove(initialSectionIndex: 0, finalSectionIndex: 1),
+        .itemMove(initialItemIndexPath: .init(item: 0, section: 0), finalItemIndexPath: .init(item: 0, section: 1)),
+        .itemMove(initialItemIndexPath: .init(item: 1, section: 0), finalItemIndexPath: .init(item: 1, section: 1)),
+
         .sectionMove(initialSectionIndex: 2, finalSectionIndex: 0),
+        .itemMove(initialItemIndexPath: .init(item: 0, section: 2), finalItemIndexPath: .init(item: 0, section: 0)),
+        .itemMove(initialItemIndexPath: .init(item: 1, section: 2), finalItemIndexPath: .init(item: 1, section: 0)),
       ])
 
     XCTAssert(
@@ -220,6 +225,17 @@ final class ModelStateUpdateTests: XCTestCase {
         modelState.indexForSectionModel(withID: initialSections[0].id, .afterUpdates) == 1 &&
         modelState.indexForSectionModel(withID: initialSections[1].id, .afterUpdates) == 2 &&
         modelState.indexForSectionModel(withID: initialSections[2].id, .afterUpdates) == 0
+      ),
+      "The model state's section models before / after updates are in an incorrect state")
+
+    XCTAssert(
+      (
+        modelState.numberOfItems(inSectionAtIndex: 0, .beforeUpdates) ==
+          modelState.numberOfItems(inSectionAtIndex: 1, .afterUpdates) &&
+        modelState.numberOfItems(inSectionAtIndex: 1, .beforeUpdates) ==
+          modelState.numberOfItems(inSectionAtIndex: 2, .afterUpdates) &&
+        modelState.numberOfItems(inSectionAtIndex: 2, .beforeUpdates) ==
+          modelState.numberOfItems(inSectionAtIndex: 0, .afterUpdates)
       ),
       "The model state's section models before / after updates are in an incorrect state")
   }


### PR DESCRIPTION
## Details

This fixes section moves causing incorrect layouts. This has shockingly been broken since `MagazineLayout` was created in 2017/18 💀

When a section is moved, `UICollectionView` also generates individual item move updates to go along with the section move. Those eventually turn into some item insertions. If we don't first clear out all existing items in the moved section, then the item insertions will insert all existing items back into the same section, effectively doubling the number of items in the section.

This bug thankfully doesn't cause a crash, but it does cause a section to take up more space than it should since it has more items in it. Keep in mind that these are layout models, not data source models, which explains why this doesn't actually cause a data-source-related crash.

AFAIK, this bug was never reported, and we never ran into it at Airbnb - turns out we don't move sections around very often!

## Related Issue

N/A

## Motivation and Context

Bug fix.

## How Has This Been Tested

Example app, unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
