### PR TITLE
Improve bounds-change handling for bottomToTop layout

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -613,15 +613,22 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     invalidationContext.invalidateLayoutMetrics = false
 
-    // If our layout direction is bottom to top we want to adjust scroll position relative to the
-    // bottom
-    if
-      case .bottomToTop = verticalLayoutDirection,
-       newBounds.maxY < currentCollectionView.contentSize.height + contentInset.bottom
-    {
-      invalidationContext.contentOffsetAdjustment = CGPoint(
-        x: 0.0,
-        y: currentCollectionView.bounds.maxY - newBounds.maxY)
+    // If our layout direction is `bottomToTop`, we need to handle the case of a non-animated bounds
+    // change by using the invalidation context's `contentOffsetAdjustment`. The calculation to get
+    // this right is odd, and is dependent on how close we were to the bottom of the collection view.
+    if case .bottomToTop = verticalLayoutDirection {
+      if newBounds.height < currentCollectionView.bounds.height {
+        invalidationContext.contentOffsetAdjustment = CGPoint(
+          x: 0.0,
+          y: currentCollectionView.bounds.midY - newBounds.midY)
+      } else if newBounds.height > currentCollectionView.bounds.height {
+        let distanceFromBottom = currentCollectionView.contentSize.height - currentCollectionView.bounds.maxY
+        let midYDelta = newBounds.midY - currentCollectionView.bounds.midY
+        let heightDelta = newBounds.height - currentCollectionView.bounds.height
+        invalidationContext.contentOffsetAdjustment = CGPoint(
+          x: 0.0,
+          y: midYDelta - min(distanceFromBottom, heightDelta))
+      }
     }
 
     return invalidationContext


### PR DESCRIPTION
## Details

This PR improves some bounds-change handling for the `bottomToTop` layout. The math is messy, but it works. There might be a deeper truth here that would simplify the calculation so that we don't need a different case for shrinking / growing bounds, and the weird clamp we need to do, but I haven't found it yet.

https://github.com/user-attachments/assets/92fe5d5d-0c2b-4a0c-8e76-fd0795e97e9e

## Motivation and Context

Fixes an issue where a bounds change caused the collection view to not preserve the bottom visible item properly.

## How Has This Been Tested

Example app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
