### PR TITLE
Adjust content offset when adjusted content insets change

### DIFF
--- a/MagazineLayout.xcodeproj/project.pbxproj
+++ b/MagazineLayout.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		60432D952E05DB41001728F0 /* ContentInsetAdjustingContentOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60432D942E05DB41001728F0 /* ContentInsetAdjustingContentOffsetTests.swift */; };
 		9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */; };
 		93424B012256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */; };
 		93540AB0282E25D90008BD6F /* ScreenPixelAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93540AAF282E25D90008BD6F /* ScreenPixelAlignment.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		60432D942E05DB41001728F0 /* ContentInsetAdjustingContentOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentInsetAdjustingContentOffsetTests.swift; sourceTree = "<group>"; };
 		9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowOffsetTrackerTests.swift; sourceTree = "<group>"; };
 		93424B002256878B003D00C0 /* MagazineLayoutFooterVisibilityMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineLayoutFooterVisibilityMode.swift; sourceTree = "<group>"; };
 		93540AAF282E25D90008BD6F /* ScreenPixelAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenPixelAlignment.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				9332FB0622969AB200483D99 /* RowOffsetTrackerTests.swift */,
 				93A1C00E21ACED0100DED67D /* TestingSupport.swift */,
 				93540AB1282E26340008BD6F /* ScreenPixelAlignmentTests.swift */,
+				60432D942E05DB41001728F0 /* ContentInsetAdjustingContentOffsetTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 			files = (
 				FDE08E162B2CC47800C9D24D /* TargetContentOffsetAnchorTests.swift in Sources */,
 				93A1C04B21ACED1100DED67D /* ModelStateInitiallSetUpTests.swift in Sources */,
+				60432D952E05DB41001728F0 /* ContentInsetAdjustingContentOffsetTests.swift in Sources */,
 				9332FB0822969B5600483D99 /* RowOffsetTrackerTests.swift in Sources */,
 				93A1C04C21ACED1100DED67D /* ModelStateLayoutTests.swift in Sources */,
 				93A1C04921ACED1100DED67D /* ModelStateEmptySectionLayoutTests.swift in Sources */,

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -787,18 +787,21 @@ public final class MagazineLayout: UICollectionViewLayout {
       return
     }
 
-    // If our layout direction is `bottomToTop`, allow changes to the bottom content inset to
-    // automatically adjust the content offset. `UICollectionView` behaves this way by default when
-    // the top content inset changes, so this adds the same behavior to the bottom.
-    let bottomContentInset = contentInset.bottom
+    // If our layout direction is `bottomToTop`, allow changes to the top and bottom content insets
+    // to automatically adjust the content offset. `UICollectionView` behaves this way by default
+    // when the top content inset changes, so this adds the same behavior to the bottom.
     if
       case .bottomToTop = verticalLayoutDirection,
-      let previousBottomContentInset,
-      previousBottomContentInset != bottomContentInset
+      let previousContentInset
     {
-      context.contentOffsetAdjustment.y = bottomContentInset - previousBottomContentInset
+      if previousContentInset.top != contentInset.top {
+        context.contentOffsetAdjustment.y += contentInset.top - previousContentInset.top
+      }
+      if previousContentInset.bottom != contentInset.bottom {
+        context.contentOffsetAdjustment.y += contentInset.bottom - previousContentInset.bottom
+      }
     }
-    previousBottomContentInset = bottomContentInset
+    previousContentInset = contentInset
 
     let shouldInvalidateLayoutMetrics = !context.invalidateEverything &&
       !context.invalidateDataSourceCounts
@@ -912,7 +915,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   private var isPerformingAnimatedBoundsChange = false
   private var targetContentOffsetAnchor: TargetContentOffsetAnchor?
   private var stagedContentOffsetAdjustment: CGPoint?
-  private var previousBottomContentInset: CGFloat?
+  private var previousContentInset: UIEdgeInsets?
 
   // Used to provide the model state with the current visible bounds for the sole purpose of
   // supporting pinned headers and footers.

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -789,7 +789,7 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     // If our layout direction is `bottomToTop`, allow changes to the top and bottom content insets
     // to automatically adjust the content offset. `UICollectionView` behaves this way by default
-    // when the top content inset changes, so this adds the same behavior to the bottom.
+    // when the top content inset changes, so this adds the same behavior.
     if
       case .bottomToTop = verticalLayoutDirection,
       let previousContentInset

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -787,6 +787,19 @@ public final class MagazineLayout: UICollectionViewLayout {
       return
     }
 
+    // If our layout direction is `bottomToTop`, allow changes to the bottom content inset to
+    // automatically adjust the content offset. `UICollectionView` behaves this way by default when
+    // the top content inset changes, so this adds the same behavior to the bottom.
+    let bottomContentInset = contentInset.bottom
+    if
+      case .bottomToTop = verticalLayoutDirection,
+      let previousBottomContentInset,
+      previousBottomContentInset != bottomContentInset
+    {
+      context.contentOffsetAdjustment.y = bottomContentInset - previousBottomContentInset
+    }
+    previousBottomContentInset = bottomContentInset
+
     let shouldInvalidateLayoutMetrics = !context.invalidateEverything &&
       !context.invalidateDataSourceCounts
 
@@ -899,6 +912,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   private var isPerformingAnimatedBoundsChange = false
   private var targetContentOffsetAnchor: TargetContentOffsetAnchor?
   private var stagedContentOffsetAdjustment: CGPoint?
+  private var previousBottomContentInset: CGFloat?
 
   // Used to provide the model state with the current visible bounds for the sole purpose of
   // supporting pinned headers and footers.

--- a/Tests/ContentInsetAdjustingContentOffsetTests.swift
+++ b/Tests/ContentInsetAdjustingContentOffsetTests.swift
@@ -1,0 +1,84 @@
+// Created by Bryn Bodayle on 6/20/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import MagazineLayout
+
+final class ContentInsetAdjustingContentOffsetTests: XCTestCase {
+
+  func testContentOffsetIsNotAdjustedForTopInsetChangeWithToTopBottomLayout() {
+    let layout = MagazineLayout(verticalLayoutDirection: .topToBottom)
+    let collectionView = StubCollectionView(
+      frame: .zero,
+      collectionViewLayout: layout)
+    let context = MagazineLayoutInvalidationContext()
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .zero)
+
+    collectionView.stubAdjustedContentInset = .init(top: 50, left: 0, bottom: 50, right: 0)
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .zero)
+  }
+
+  func testContentOffsetIsAdjustedForTopInsetChangeWithBottomToTopLayout() {
+    let layout = MagazineLayout(verticalLayoutDirection: .bottomToTop)
+    let collectionView = StubCollectionView(
+      frame: .zero,
+      collectionViewLayout: layout)
+    let context = MagazineLayoutInvalidationContext()
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .zero)
+
+    collectionView.stubAdjustedContentInset = .init(top: 50, left: 0, bottom: 0, right: 0)
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .init(x: 0, y: 50))
+  }
+
+  func testContentOffsetIsAdjustedForBottomInsetChangeWithBottomToTopLayout() {
+    let layout = MagazineLayout(verticalLayoutDirection: .bottomToTop)
+    let collectionView = StubCollectionView(
+      frame: .zero,
+      collectionViewLayout: layout)
+    let context = MagazineLayoutInvalidationContext()
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .zero)
+
+    collectionView.stubAdjustedContentInset = .init(top: 0, left: 0, bottom: 75, right: 0)
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .init(x: 0, y: 75))
+  }
+
+  func testContentOffsetIsAdjustedForTopAndBottomInsetChangesWithBottomToTopLayout() {
+    let layout = MagazineLayout(verticalLayoutDirection: .bottomToTop)
+    let collectionView = StubCollectionView(
+      frame: .zero,
+      collectionViewLayout: layout)
+    let context = MagazineLayoutInvalidationContext()
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .zero)
+
+    collectionView.stubAdjustedContentInset = .init(top: 100, left: 0, bottom: 100, right: 0)
+    layout.invalidateLayout(with: context)
+    XCTAssertEqual(context.contentOffsetAdjustment, .init(x: 0, y: 200))
+  }
+}
+
+private class StubCollectionView: UICollectionView {
+
+  var stubAdjustedContentInset: UIEdgeInsets = .zero
+  override var adjustedContentInset: UIEdgeInsets {
+    stubAdjustedContentInset
+  }
+}

--- a/Tests/ScreenPixelAlignmentTests.swift
+++ b/Tests/ScreenPixelAlignmentTests.swift
@@ -1,9 +1,6 @@
 // Created by Bryan Keller on 5/12/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-// Created by Bryan Keller on 3/31/20.
-// Copyright © 2020 Airbnb Inc. All rights reserved.
-
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
When the bottom content inset changes, nudge the content offset by the same amount so that bottom content stays pinned (when using bottomToTop layout). We get this behavior for free at the top edge.

