### PR TITLE
Fix jumpy scrolling due to incorrect target content offset calculation

### DIFF
--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -105,6 +105,17 @@ final class ModelState {
     return nil
   }
 
+  func isItemHeightSettled(indexPath: IndexPath) -> Bool {
+    let item = sectionModels(for: .afterUpdates)[indexPath.section].itemModel(
+      atIndex: indexPath.item)
+    switch item.sizeMode.heightMode {
+    case .static:
+      return true
+    case .dynamicAndStretchToTallestItemInRow, .dynamic(_):
+      return item.preferredHeight != nil
+    }
+  }
+
   func itemModelHeightModeDuringPreferredAttributesCheck(
     at indexPath: IndexPath)
     -> MagazineLayoutItemHeightMode?

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -1294,7 +1294,11 @@ public final class MagazineLayout: UICollectionViewLayout {
     }
     visibleItemLocationFramePairs.sort { $0.elementLocation < $1.elementLocation }
 
-    let firstVisibleItemLocationFramePair = visibleItemLocationFramePairs.first
+    let firstVisibleItemLocationFramePair = visibleItemLocationFramePairs.first {
+      // When scrolling up, only calculate a a target content offset based on visible, already-sized
+      // cells. Otherwise, scrolling will be jumpy.
+      modelState.isItemHeightSettled(indexPath: $0.elementLocation.indexPath)
+    }
     let lastVisibleItemLocationFramePair = visibleItemLocationFramePairs.last
 
     guard


### PR DESCRIPTION
## Details

This PR fixes an issue with target content offset calculations that causes scrolling to be jumpy when scrolling up. I originally broke this [here](https://github.com/airbnb/MagazineLayout/pull/129/files#diff-d77816f807be47f68fc24a016836021fbaa98c7aa4458d7b908a6fda34a6f4b1L1266).

The fix is to base our target content offset calculation on already-sized cells, never a cell that's about to be self-sized.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

