### PR TITLE
Improve target content offset calculation

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -1298,7 +1298,8 @@ public final class MagazineLayout: UICollectionViewLayout {
       // When scrolling up, only calculate a target content offset based on visible, already-sized
       // cells. Otherwise, scrolling will be jumpy.
       modelState.isItemHeightSettled(indexPath: $0.elementLocation.indexPath)
-    }
+    } ?? visibleItemLocationFramePairs.first // fallback to the first item if we can't find one with a settled height
+
     let lastVisibleItemLocationFramePair = visibleItemLocationFramePairs.last
 
     guard


### PR DESCRIPTION
## Details

This improves upon the last change which fixed some jumpy scrolling due to calculating a target content offset with an item that doesn't have its final height yet. The logic was slightly flawed, as we should still fall back to an estimated height item if no self-sized item is found.

This broke scroll-to-bottom behavior on the Airbnb messages screen. 