### PR TITLE
Fix reloading after sections updates

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -102,6 +102,19 @@ public final class MagazineLayout: UICollectionViewLayout {
       prepareActions.contains(.recreateSectionModels)
     {
       hasPinnedHeaderOrFooter = false
+      lastSizedElementMinY = nil
+      lastSizedElementPreferredHeight = nil
+    }
+
+    // Recreate section models from scratch if necessary
+    if prepareActions.contains(.recreateSectionModels) {
+      var sections = [SectionModel]()
+      for sectionIndex in 0..<currentCollectionView.numberOfSections {
+        let sectionModel = sectionModelForSection(atIndex: sectionIndex)
+        sections.append(sectionModel)
+      }
+
+      modelState.setSections(sections)
     }
 
     // Update layout metrics if necessary
@@ -134,25 +147,6 @@ public final class MagazineLayout: UICollectionViewLayout {
           modelState.updateItemSizeMode(to: sizeModeForItem(at: indexPath), forItemAt: indexPath)
         }
       }
-    }
-
-    // Recreate section models from scratch if necessary
-    if prepareActions.contains(.recreateSectionModels) {
-      var sections = [SectionModel]()
-      for sectionIndex in 0..<currentCollectionView.numberOfSections {
-        let sectionModel = sectionModelForSection(atIndex: sectionIndex)
-        sections.append(sectionModel)
-      }
-
-      modelState.setSections(sections)
-    }
-
-    if
-      prepareActions.contains(.recreateSectionModels) ||
-      prepareActions.contains(.updateLayoutMetrics)
-    {
-      lastSizedElementMinY = nil
-      lastSizedElementPreferredHeight = nil
     }
 
     prepareActions = []


### PR DESCRIPTION
## Details

The CollectionView reload is triggered by this func from the **MagazineLayout Library** :

<img width="720" height="214" alt="image" src="https://github.com/user-attachments/assets/7d245436-1185-4b62-8fad-edf9b04a6401" />

If we follow that call it comes from the **override public func prepare()** here :

<img width="1920" height="1716" alt="image (2)" src="https://github.com/user-attachments/assets/0d03e631-880b-49c1-b6fa-e359c9ec7433" />

The **prepareActions** is a bit field, and you check for **updateLayoutMetrics** (which triggers the updates) and just bellow that highlighted line of code on the screenshot the following condition checks for **recreateSectionModels** which are both set to true in our situation.

## The fix

<img width="671" height="215" alt="Screenshot 2025-08-22 at 2 06 23 pm" src="https://github.com/user-attachments/assets/f72e0866-4255-4d41-bb2a-059c6b266796" />

The **recreateSectionModels** code should be called before **updateLayoutMetrics** if **recreateSectionModels** is set to true because there is no need to update the sections if we are going to recreate them anyway right after the update.

## Related Issue

We have a very old crash that is occurring on our main iPad app.
The crash happens following these steps :
- Launch the iPad App in portrait mode(logged in), land on the Home Page
- Go to settings and Sign Out
- Attempt to sign in again
- Rotate to landscape & cancel the Login Modal
- Go to the Home Page
-> CRASH

It crashes because there is more sections on the Home Page when the user is logged (34 sections) in compared to when the user is logged out (28 sections), some sections are based on the user's preferences and his content, like recommended, suggested...). 
The current code implementation tries to update the existing sections and an out of bounds crash will occur because the number of sections logged out are inferior and it will attempt to update a section that just doesn't exist.

## Motivation and Context

The current behaviour is the following : 
- Check if updates are required, if yes, updates them
- Check if the sections should be completely re-created, if yes, recreates them

This fix just swap the 2 steps, check for recreation first and then for updates.

## How Has This Been Tested

The reproducibility of this crash was 100% in our situation (following steps detailed up here).

Tested on :
- Simulators, iPad mini, iPad 11 Pro, 13 Pro
- Devices, multiple iPad mini, & iPad pros
- Tested by QA team and Engineers over a course of a week
- Reproduction rate of 0% after the fix

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
