### PR TITLE
Reduce index path lookups

### DIFF
--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -21,6 +21,6 @@ import UIKit
 enum TargetContentOffsetAnchor: Equatable {
   case top
   case bottom
-  case topItem(id: UInt64, distanceFromTop: CGFloat)
-  case bottomItem(id: UInt64, distanceFromBottom: CGFloat)
+  case topItem(id: UInt64, elementLocation: ElementLocation, distanceFromTop: CGFloat)
+  case bottomItem(id: UInt64, elementLocation: ElementLocation, distanceFromBottom: CGFloat)
 }

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -227,7 +227,9 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     if let layoutStateBeforeCollectionViewUpdates{
       let targetContentOffsetAnchor = layoutStateBeforeCollectionViewUpdates.targetContentOffsetAnchor
-      let targetYOffset = layoutState.yOffset(for: targetContentOffsetAnchor)
+      let targetYOffset = layoutState.yOffset(
+        for: targetContentOffsetAnchor,
+        isPerformingBatchUpdates: true)
       let context = MagazineLayoutInvalidationContext()
       context.invalidateLayoutMetrics = false
       context.contentOffsetAdjustment.y = targetYOffset - layoutState.bounds.minY
@@ -676,7 +678,9 @@ public final class MagazineLayout: UICollectionViewLayout {
           layoutStateBeforeAnimatedBoundsChange ??
           self.layoutState
       ).targetContentOffsetAnchor
-      let targetYOffsetBefore = layoutState.yOffset(for: targetContentOffsetAnchor)
+      let targetYOffsetBefore = layoutState.yOffset(
+        for: targetContentOffsetAnchor,
+        isPerformingBatchUpdates: layoutStateBeforeCollectionViewUpdates != nil)
 
       modelState.updateItemHeight(
         toPreferredHeight: preferredAttributes.size.height,
@@ -690,7 +694,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         context.contentOffsetAdjustment.y = layoutState.maxContentOffset.y - layoutState.bounds.minY
 
       case .topItem, .bottomItem:
-        let targetYOffsetAfter = layoutState.yOffset(for: targetContentOffsetAnchor)
+        let targetYOffsetAfter = layoutState.yOffset(
+          for: targetContentOffsetAnchor,
+          isPerformingBatchUpdates: layoutStateBeforeCollectionViewUpdates != nil)
         context.contentOffsetAdjustment.y = targetYOffsetAfter - targetYOffsetBefore
       }
 
@@ -817,7 +823,9 @@ public final class MagazineLayout: UICollectionViewLayout {
       return super.targetContentOffset(forProposedContentOffset: proposedContentOffset)
     }
 
-    let yOffset = layoutState.yOffset(for: layoutStateBefore.targetContentOffsetAnchor)
+    let yOffset = layoutState.yOffset(
+      for: layoutStateBefore.targetContentOffsetAnchor,
+      isPerformingBatchUpdates: layoutStateBeforeCollectionViewUpdates != nil)
 
     targetContentOffsetCompensatingYOffsetForAppearingItem = proposedContentOffset.y - yOffset
 

--- a/Tests/LayoutStateTargetContentOffsetTests.swift
+++ b/Tests/LayoutStateTargetContentOffsetTests.swift
@@ -40,8 +40,9 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
       scale: 1,
       verticalLayoutDirection: .topToBottom)
-    let id = layoutState.modelState.idForItemModel(at: IndexPath(item: 6, section: 0))!
-    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, distanceFromTop: -25))
+    let indexPath = IndexPath(item: 6, section: 0)
+    let id = layoutState.modelState.idForItemModel(at: indexPath)!
+    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, elementLocation: ElementLocation(indexPath: indexPath), distanceFromTop: -25))
   }
 
   func testAnchor_TopToBottom_ScrolledToBottom() throws {
@@ -61,8 +62,9 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: measurementLayoutState.contentInset,
       scale: measurementLayoutState.scale,
       verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
-    let id = layoutState.modelState.idForItemModel(at: IndexPath(item: 9, section: 0))!
-    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, distanceFromTop: 25))
+    let indexPath = IndexPath(item: 9, section: 0)
+    let id = layoutState.modelState.idForItemModel(at: indexPath)!
+    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, elementLocation: ElementLocation(indexPath: indexPath), distanceFromTop: 25))
   }
 
   func testAnchor_TopToBottom_NoFullyVisibleCells_UsesFallback() throws {
@@ -78,8 +80,9 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
 
     // Since no items are fully visible, the fallback should use the first partially visible item
     // instead of returning .top or .bottom
-    let id = layoutState.modelState.idForItemModel(at: IndexPath(item: 0, section: 0))!
-    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, distanceFromTop: -300))
+    let indexPath = IndexPath(item: 0, section: 0)
+    let id = layoutState.modelState.idForItemModel(at: indexPath)!
+    XCTAssert(layoutState.targetContentOffsetAnchor == .topItem(id: id, elementLocation: ElementLocation(indexPath: indexPath), distanceFromTop: -300))
   }
 
   // MARK: Bottom-to-Top Anchor Tests
@@ -92,8 +95,9 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
       scale: 1,
       verticalLayoutDirection: .bottomToTop)
-    let id = layoutState.modelState.idForItemModel(at: IndexPath(item: 3, section: 0))!
-    XCTAssert(layoutState.targetContentOffsetAnchor == .bottomItem(id: id, distanceFromBottom: -90))
+    let indexPath = IndexPath(item: 3, section: 0)
+    let id = layoutState.modelState.idForItemModel(at: indexPath)!
+    XCTAssert(layoutState.targetContentOffsetAnchor == .bottomItem(id: id, elementLocation: ElementLocation(indexPath: indexPath), distanceFromBottom: -90))
   }
 
   func testAnchor_BottomToTop_ScrolledToMiddle() throws {
@@ -104,8 +108,9 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
       scale: 1,
       verticalLayoutDirection: .bottomToTop)
-    let id = layoutState.modelState.idForItemModel(at: IndexPath(item: 10, section: 0))!
-    XCTAssert(layoutState.targetContentOffsetAnchor == .bottomItem(id: id, distanceFromBottom: -10))
+    let indexPath = IndexPath(item: 10, section: 0)
+    let id = layoutState.modelState.idForItemModel(at: indexPath)!
+    XCTAssert(layoutState.targetContentOffsetAnchor == .bottomItem(id: id, elementLocation: ElementLocation(indexPath: indexPath), distanceFromBottom: -10))
   }
 
   func testAnchor_BottomToTop_ScrolledToBottom() throws {
@@ -139,7 +144,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: 1,
       verticalLayoutDirection: .topToBottom)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == -50)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == -50)
   }
 
   func testOffset_TopToBottom_ScrolledToMiddle() {
@@ -151,7 +156,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: 1,
       verticalLayoutDirection: .topToBottom)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == 500)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 500)
   }
 
   func testOffset_TopToBottom_ScrolledToBottom() {
@@ -172,7 +177,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: measurementLayoutState.scale,
       verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == 690)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 690)
   }
 
   // MARK: Bottom-to-Top Target Content Offset Tests
@@ -186,7 +191,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: 1,
       verticalLayoutDirection: .bottomToTop)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == -50)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == -50)
   }
 
   func testOffset_BottomToTop_ScrolledToMiddle() {
@@ -198,7 +203,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: 1,
       verticalLayoutDirection: .bottomToTop)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == 500)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 500)
   }
 
   func testOffset_BottomToTop_ScrolledToBottom() {
@@ -219,7 +224,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       scale: measurementLayoutState.scale,
       verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
-    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor) == 690)
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 690)
   }
 
   // MARK: Private


### PR DESCRIPTION
## Details

This PR reduces calls to `modelState.indexPathForItem(withID:)` when calculating the `yOffset` for a `targetContentOffsetAnchor`. In most cases, like when scrolling and self-sizing cells, we already know the index path of the `targetContentOffsetAnchor` item - it's only when performing batch updates that we need to look up an index path using an ID (an `O(n)` search), since the index path might have changes as a result of batch updates.

## Motivation and Context

Perf
