### PR TITLE
Fix the contentOffsetAdjustment when overscrolling

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Build
         run: xcodebuild clean build -scheme MagazineLayout -destination "generic/platform=iOS Simulator"
       - name: Run tests
-        run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 16,OS=18.4"
+        run: xcodebuild clean test -project MagazineLayout.xcodeproj -scheme MagazineLayout -destination "name=iPhone 17,OS=26.2"

--- a/MagazineLayout/LayoutCore/LayoutState.swift
+++ b/MagazineLayout/LayoutCore/LayoutState.swift
@@ -89,8 +89,8 @@ struct LayoutState {
         at: lastVisibleItemLocationFramePair.elementLocation.indexPath)
     else {
       switch verticalLayoutDirection {
-      case .topToBottom: return .top
-      case .bottomToTop: return .bottom
+      case .topToBottom: return .top(overScrollDistance: 0)
+      case .bottomToTop: return .bottom(overScrollDistance: 0)
       }
     }
 
@@ -118,7 +118,7 @@ struct LayoutState {
     case .topToBottom:
       switch position {
       case .atTop:
-        return .top
+        return .top(overScrollDistance: top - bounds.minY)
       case .inMiddle, .atBottom:
         let top = bounds.minY + contentInset.top
         let distanceFromTop = firstVisibleItemLocationFramePair.frame.minY - top
@@ -137,7 +137,7 @@ struct LayoutState {
           elementLocation: lastVisibleItemLocationFramePair.elementLocation,
           distanceFromBottom: distanceFromBottom.alignedToPixel(forScreenWithScale: scale))
       case .atBottom:
-        return .bottom
+        return .bottom(overScrollDistance: bounds.minY - bottom)
       }
     }
   }
@@ -148,11 +148,11 @@ struct LayoutState {
     -> CGFloat
   {
     switch targetContentOffsetAnchor {
-    case .top:
-      return minContentOffset.y
+    case .top(let overScrollDistance):
+      return minContentOffset.y - overScrollDistance
 
-    case .bottom:
-      return maxContentOffset.y
+    case .bottom(let overScrollDistance):
+      return maxContentOffset.y + overScrollDistance
 
     case .topItem(let id, let _elementLocation, let distanceFromTop):
       let elementLocation =

--- a/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
+++ b/MagazineLayout/LayoutCore/Types/TargetContentOffsetAnchor.swift
@@ -19,8 +19,8 @@ import UIKit
 
 /// Anchors representing how the collection view prioritizes keeping certain items visible in target content offset calculations.
 enum TargetContentOffsetAnchor: Equatable {
-  case top
-  case bottom
+  case top(overScrollDistance: CGFloat)
+  case bottom(overScrollDistance: CGFloat)
   case topItem(id: UInt64, elementLocation: ElementLocation, distanceFromTop: CGFloat)
   case bottomItem(id: UInt64, elementLocation: ElementLocation, distanceFromBottom: CGFloat)
 }

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -687,11 +687,11 @@ public final class MagazineLayout: UICollectionViewLayout {
         forItemAt: preferredAttributes.indexPath)
 
       switch targetContentOffsetAnchor {
-      case .top:
-        context.contentOffsetAdjustment.y = layoutState.minContentOffset.y - layoutState.bounds.minY
+      case .top(let overScrollDistance):
+        context.contentOffsetAdjustment.y = layoutState.minContentOffset.y - overScrollDistance - layoutState.bounds.minY
 
-      case .bottom:
-        context.contentOffsetAdjustment.y = layoutState.maxContentOffset.y - layoutState.bounds.minY
+      case .bottom(let overScrollDistance):
+        context.contentOffsetAdjustment.y = layoutState.maxContentOffset.y + overScrollDistance - layoutState.bounds.minY
 
       case .topItem, .bottomItem:
         let targetYOffsetAfter = layoutState.yOffset(

--- a/Tests/LayoutStateTargetContentOffsetTests.swift
+++ b/Tests/LayoutStateTargetContentOffsetTests.swift
@@ -29,7 +29,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
       scale: 1,
       verticalLayoutDirection: .topToBottom)
-    XCTAssert(layoutState.targetContentOffsetAnchor == .top)
+    XCTAssert(layoutState.targetContentOffsetAnchor == .top(overScrollDistance: 0))
   }
 
   func testAnchor_TopToBottom_ScrolledToMiddle() throws {
@@ -130,7 +130,7 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       contentInset: measurementLayoutState.contentInset,
       scale: measurementLayoutState.scale,
       verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
-    XCTAssert(layoutState.targetContentOffsetAnchor == .bottom)
+    XCTAssert(layoutState.targetContentOffsetAnchor == .bottom(overScrollDistance: 0))
   }
 
   // MARK: Top-to-Bottom Target Content Offset Tests
@@ -180,6 +180,20 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
     XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 690)
   }
 
+  func testOffset_TopToBottom_OverscrolledPastTop() {
+    // bounds.minY = -80 is 30px past minContentOffset.y (-50), simulating rubber-banding
+    let bounds = CGRect(x: 0, y: -80, width: 300, height: 400)
+    let layoutState = LayoutState(
+      modelState: modelState(bounds: bounds),
+      bounds: bounds,
+      contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
+      scale: 1,
+      verticalLayoutDirection: .topToBottom)
+    let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
+    XCTAssert(targetContentOffsetAnchor == .top(overScrollDistance: 30))
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == -80)
+  }
+
   // MARK: Bottom-to-Top Target Content Offset Tests
 
   func testOffset_BottomToTop_ScrolledToTop() {
@@ -225,6 +239,29 @@ final class LayoutStateTargetContentOffsetTests: XCTestCase {
       verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
     let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
     XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == 690)
+  }
+
+  func testOffset_BottomToTop_OverscrolledPastBottom() {
+    let measurementBounds = CGRect(x: 0, y: 0, width: 300, height: 400)
+    let measurementLayoutState = LayoutState(
+      modelState: modelState(bounds: measurementBounds),
+      bounds: measurementBounds,
+      contentInset: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0),
+      scale: 1,
+      verticalLayoutDirection: .bottomToTop)
+    let maxContentOffset = measurementLayoutState.maxContentOffset
+
+    // 25px past maxContentOffset, simulating rubber-banding
+    let bounds = CGRect(x: 0, y: maxContentOffset.y + 25, width: 300, height: 400)
+    let layoutState = LayoutState(
+      modelState: modelState(bounds: bounds),
+      bounds: bounds,
+      contentInset: measurementLayoutState.contentInset,
+      scale: measurementLayoutState.scale,
+      verticalLayoutDirection: measurementLayoutState.verticalLayoutDirection)
+    let targetContentOffsetAnchor = layoutState.targetContentOffsetAnchor
+    XCTAssert(targetContentOffsetAnchor == .bottom(overScrollDistance: 25))
+    XCTAssert(layoutState.yOffset(for: targetContentOffsetAnchor, isPerformingBatchUpdates: false) == maxContentOffset.y + 25)
   }
 
   // MARK: Private


### PR DESCRIPTION
## Details

This fixes an issue that could cause jumpy scrolling when rubber-banding / over-scrolling at the top or bottom of the collection view. While over-scrolling, if an item self-sizes due to its visibility changing, we need to account for the over-scroll amount when calculating a `contentOffsetAdjustment`. Before this change, we'd always calculate that offset without taking into account the over-scroll, causing the collection view to snap to its min / max content offset (even though you were beyond that).


## Review

@brynbodayle 