### PR TITLE
Add flag to test reducing unnecessary layout invalidations

### DIFF
--- a/MagazineLayout/Public/MagazineLayoutInvalidationContext.swift
+++ b/MagazineLayout/Public/MagazineLayoutInvalidationContext.swift
@@ -20,8 +20,15 @@ import UIKit
 /// Used to indicate that collection view properties and/or delegate layout metrics changed.
 public final class MagazineLayoutInvalidationContext: UICollectionViewLayoutInvalidationContext {
 
-  /// Indicates whether to recompute the positions and sizes of elements based on the current
-  /// collection view and delegate layout metrics.
-  public var invalidateLayoutMetrics = true
+  /// A temporary flag to enable safely testing a change to how layout invalidation works.
+  public static var _invalidateLayoutMetricsDefaultValue = true
+
+  /// Indicates whether to recompute the positions and sizes of elements based on the current collection view and delegate layout
+  /// metrics.
+  ///
+  /// Defaults to `false`. Set to `true` when delegate-provided layout values (e.g. item size
+  /// modes, header/footer visibility, section metrics) have changed and the layout needs to
+  /// re-query the delegate.
+  public var invalidateLayoutMetrics = _invalidateLayoutMetricsDefaultValue
 
 }


### PR DESCRIPTION
## Details

This PR adds a temporary flag to make MagazineLayout perform less work by default whenever the layout is invalidated. Will A/B test this in the Airbnb app to see performance impact.