### PR TITLE
ci: add explicit workflow-level permissions to swift

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15


### PR DESCRIPTION
This adds an explicit `permissions:` block to the Swift CI build and test workflow so the GitHub-issued token for runs of `swift.yml` is granted only the scopes the job actually uses.

The change is `permissions: contents: read` at the top level. The workflow checks out the repo and runs its declared steps; there is no `git push`, no `gh release create`, no comment-on-PR action, no API write. `contents: read` is therefore the minimum sufficient scope.

Why bother for a workflow that looks innocuous: the worry is not what this workflow does today, it is what an action used inside it might be coerced into doing tomorrow if a third-party dependency in the action chain is compromised. The CVE-2025-30066 (tj-actions/changed-files, March 2025) incident is the canonical recent example. Without an explicit `permissions:` block, the run inherits the repository-default token scope, which is permissive on many older repos.

Aligns with GitHub's own [token-hardening guidance](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and OpenSSF Scorecard (Token-Permissions). Standalone diff, no behavior change, YAML re-parses with `yaml.safe_load`.
