### PR TITLE
Bk/performance optimizations 2

### DIFF
--- a/MagazineLayout/LayoutCore/ModelState.swift
+++ b/MagazineLayout/LayoutCore/ModelState.swift
@@ -223,11 +223,10 @@ final class ModelState {
     }
 
     var itemFrame: CGRect!
-    mutateSectionModels(
-      withUnsafeMutableBufferPointer: { directlyMutableSectionModels in
-        itemFrame = directlyMutableSectionModels[itemLocation.sectionIndex].calculateFrameForItem(
-          atIndex: itemLocation.elementIndex)
-      })
+    sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+      itemFrame = sectionModels[itemLocation.sectionIndex].calculateFrameForItem(
+        atIndex: itemLocation.elementIndex)
+    }
 
     itemFrame.origin.y += sectionMinY
     return itemFrame
@@ -243,15 +242,14 @@ final class ModelState {
 
     let currentVisibleBounds = currentVisibleBoundsProvider()
     var headerFrame: CGRect?
-    mutateSectionModels(
-      withUnsafeMutableBufferPointer: { directlyMutableSectionModels in
-        headerFrame = directlyMutableSectionModels[sectionIndex].calculateFrameForHeader(
-          inSectionVisibleBounds: CGRect(
-            x: currentVisibleBounds.minX,
-            y: currentVisibleBounds.minY - sectionMinY,
-            width: currentVisibleBounds.width,
-            height: currentVisibleBounds.height))
-      })
+    sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+      headerFrame = sectionModels[sectionIndex].calculateFrameForHeader(
+        inSectionVisibleBounds: CGRect(
+          x: currentVisibleBounds.minX,
+          y: currentVisibleBounds.minY - sectionMinY,
+          width: currentVisibleBounds.width,
+          height: currentVisibleBounds.height))
+      }
 
     headerFrame?.origin.y += sectionMinY
     return headerFrame
@@ -267,15 +265,14 @@ final class ModelState {
 
     let currentVisibleBounds = currentVisibleBoundsProvider()
     var footerFrame: CGRect?
-    mutateSectionModels(
-      withUnsafeMutableBufferPointer: { directlyMutableSectionModels in
-        footerFrame = directlyMutableSectionModels[sectionIndex].calculateFrameForFooter(
+    sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+        footerFrame = sectionModels[sectionIndex].calculateFrameForFooter(
           inSectionVisibleBounds: CGRect(
             x: currentVisibleBounds.minX,
             y: currentVisibleBounds.minY - sectionMinY,
             width: currentVisibleBounds.width,
             height: currentVisibleBounds.height))
-      })
+      }
 
     footerFrame?.origin.y += sectionMinY
     return footerFrame
@@ -290,10 +287,9 @@ final class ModelState {
     }
 
     var backgroundFrame: CGRect?
-    mutateSectionModels(
-      withUnsafeMutableBufferPointer: { directlyMutableSectionModels in
-        backgroundFrame = directlyMutableSectionModels[sectionIndex].calculateFrameForBackground()
-      })
+    sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+      backgroundFrame = sectionModels[sectionIndex].calculateFrameForBackground()
+    }
 
     backgroundFrame?.origin.y += sectionMinY
     return backgroundFrame
@@ -359,9 +355,32 @@ final class ModelState {
 
   func updateMetrics(
     to sectionMetrics: MagazineLayoutSectionMetrics,
+    forSectionAtIndex sectionIndex: Int,
+    sectionModel: inout SectionModel)
+  {
+    let didUpdate = sectionModel.updateMetrics(to: sectionMetrics)
+    if didUpdate {
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+    }
+  }
+
+  func updateMetrics(
+    to sectionMetrics: MagazineLayoutSectionMetrics,
     forSectionAtIndex sectionIndex: Int)
   {
     sectionModels[sectionIndex].updateMetrics(to: sectionMetrics)
+
+    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+  }
+
+  func updateItemSizeModes(
+    forSectionAtIndex sectionIndex: Int,
+    sectionModel: inout SectionModel,
+    sizeModeProvider: (_ itemIndex: Int) -> MagazineLayoutItemSizeMode)
+  {
+    sectionModel.updateItemSizeModes(sizeModeProvider)
+
+    // TODO: Only invalidate if something changes
     invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
   }
 
@@ -369,6 +388,19 @@ final class ModelState {
     sectionModels[indexPath.section].updateItemSizeMode(to: sizeMode, atIndex: indexPath.item)
 
     invalidateSectionMaxYsCacheForSectionIndices(startingAt: indexPath.section)
+  }
+
+  func setHeader(
+    _ headerModel: HeaderModel,
+    forSectionAtIndex sectionIndex: Int,
+    sectionModel: inout SectionModel)
+  {
+    sectionModel.setHeader(headerModel)
+
+    // TODO: Only invalidate if something changes
+    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+
+    prepareElementLocationsForFlattenedIndices()
   }
 
   func setHeader(_ headerModel: HeaderModel, forSectionAtIndex sectionIndex: Int) {
@@ -379,11 +411,31 @@ final class ModelState {
     prepareElementLocationsForFlattenedIndices()
   }
 
+  func removeHeader(forSectionAtIndex sectionIndex: Int, sectionModel: inout SectionModel) {
+    if sectionModel.removeHeader() {
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+      prepareElementLocationsForFlattenedIndices()
+    }
+  }
+
   func removeHeader(forSectionAtIndex sectionIndex: Int) {
     if sectionModels[sectionIndex].removeHeader() {
       invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
       prepareElementLocationsForFlattenedIndices()
     }
+  }
+
+  func setFooter(
+    _ footerModel: FooterModel,
+    forSectionAtIndex sectionIndex: Int,
+    sectionModel: inout SectionModel)
+  {
+    sectionModel.setFooter(footerModel)
+
+    // TODO: Only invalidate if something changes
+    invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+
+    prepareElementLocationsForFlattenedIndices()
   }
 
   func setFooter(_ footerModel: FooterModel, forSectionAtIndex sectionIndex: Int) {
@@ -394,6 +446,13 @@ final class ModelState {
     prepareElementLocationsForFlattenedIndices()
   }
 
+  func removeFooter(forSectionAtIndex sectionIndex: Int, sectionModel: inout SectionModel) {
+    if sectionModel.removeFooter() {
+      invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
+      prepareElementLocationsForFlattenedIndices()
+    }
+  }
+
   func removeFooter(forSectionAtIndex sectionIndex: Int) {
     if sectionModels[sectionIndex].removeFooter() {
       invalidateSectionMaxYsCacheForSectionIndices(startingAt: sectionIndex)
@@ -401,10 +460,27 @@ final class ModelState {
     }
   }
 
+  func setBackground(
+    _ backgroundModel: BackgroundModel,
+    forSectionAtIndex sectionIndex: Int,
+    sectionModel: inout SectionModel)
+  {
+    sectionModel.setBackground(backgroundModel)
+
+    // TODO: Only invalidate if something changes
+    prepareElementLocationsForFlattenedIndices()
+  }
+
   func setBackground(_ backgroundModel: BackgroundModel, forSectionAtIndex sectionIndex: Int) {
     sectionModels[sectionIndex].setBackground(backgroundModel)
 
     prepareElementLocationsForFlattenedIndices()
+  }
+
+  func removeBackground(forSectionAtIndex sectionIndex: Int, sectionModel: inout SectionModel) {
+    if sectionModel.removeBackground() {
+      prepareElementLocationsForFlattenedIndices()
+    }
   }
 
   func removeBackground(forSectionAtIndex sectionIndex: Int) {
@@ -497,6 +573,16 @@ final class ModelState {
     itemIndexPathsToDelete.removeAll()
   }
 
+  func forEachSectionModel(
+    _ mutator: (_ sectionIndex: Int, _ sectionModel: inout SectionModel) -> Void)
+  {
+    sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+      for sectionIndex in 0..<sectionModels.count {
+        mutator(sectionIndex, &sectionModels[sectionIndex])
+      }
+    }
+  }
+
   // MARK: Private
 
   private let currentVisibleBoundsProvider: () -> CGRect
@@ -510,13 +596,6 @@ final class ModelState {
   private var backgroundLocationsForFlattenedIndices = [Int: ElementLocation]()
   private var itemLocationsForFlattenedIndices = [Int: ElementLocation]()
 
-  private func mutateSectionModels(
-    withUnsafeMutableBufferPointer body: (inout UnsafeMutableBufferPointer<SectionModel>) -> Void)
-  {
-    // Accessing these arrays using unsafe, untyped (raw) pointers
-    // avoids expensive copy-on-writes and Swift retain / release calls.
-    sectionModels.withUnsafeMutableBufferPointer(body)
-  }
 
   private func prepareElementLocationsForFlattenedIndices() {
     headerLocationsForFlattenedIndices.removeAll()
@@ -696,29 +775,55 @@ final class ModelState {
       return
     }
 
-    for sectionIndex in sectionIndex..<sectionMaxYsCache.count {
-      sectionMaxYsCache[sectionIndex] = nil
+    if MagazineLayout._enableExperimentalOptimizations {
+      sectionMaxYsCache.withUnsafeMutableBufferPointer { sectionMaxYsCache in
+        for sectionIndex in sectionIndex..<sectionMaxYsCache.count {
+          sectionMaxYsCache[sectionIndex] = nil
+        }
+      }
+    } else {
+      for sectionIndex in sectionIndex..<sectionMaxYsCache.count {
+        sectionMaxYsCache[sectionIndex] = nil
+      }
     }
   }
 
   private func reloadSectionModels(
     sectionModelReloadIndexPairs: [(sectionModel: SectionModel, reloadIndex: Int)])
   {
-    for (sectionModel, reloadIndex) in sectionModelReloadIndexPairs {
-      sectionModels.remove(at: reloadIndex)
-      sectionModels.insert(sectionModel, at: reloadIndex)
+    if MagazineLayout._enableExperimentalOptimizations {
+      sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+        for (sectionModel, reloadIndex) in sectionModelReloadIndexPairs {
+          sectionModels[reloadIndex] = sectionModel
+        }
+      }
+    } else {
+      for (sectionModel, reloadIndex) in sectionModelReloadIndexPairs {
+        sectionModels.remove(at: reloadIndex)
+        sectionModels.insert(sectionModel, at: reloadIndex)
+      }
     }
   }
 
   private func reloadItemModels(
     itemModelReloadIndexPathPairs: [(itemModel: ItemModel, reloadIndexPath: IndexPath)])
   {
-    for (itemModel, reloadIndexPath) in itemModelReloadIndexPathPairs {
-      sectionModels[reloadIndexPath.section].deleteItemModel(
-        atIndex: reloadIndexPath.item)
-      sectionModels[reloadIndexPath.section].insert(
-        itemModel, atIndex:
-        reloadIndexPath.item)
+    if MagazineLayout._enableExperimentalOptimizations {
+      sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+        for (itemModel, reloadIndexPath) in itemModelReloadIndexPathPairs {
+          sectionModels[reloadIndexPath.section].updateItemModel(
+            atIndex: reloadIndexPath.item,
+            to: itemModel)
+        }
+      }
+    } else {
+      for (itemModel, reloadIndexPath) in itemModelReloadIndexPathPairs {
+        sectionModels[reloadIndexPath.section].deleteItemModel(
+          atIndex: reloadIndexPath.item)
+        sectionModels[reloadIndexPath.section].insert(
+          itemModel,
+          atIndex: reloadIndexPath.item)
+      }
     }
   }
 
@@ -731,9 +836,18 @@ final class ModelState {
 
   private func deleteItemModels(atIndexPaths indexPathsOfItemModelsToDelete: [IndexPath]) {
     // Always delete in descending order
-    for indexPathOfItemModelToDelete in (indexPathsOfItemModelsToDelete.sorted { $0 > $1 }) {
-      sectionModels[indexPathOfItemModelToDelete.section].deleteItemModel(
-        atIndex: indexPathOfItemModelToDelete.item)
+    if MagazineLayout._enableExperimentalOptimizations {
+      sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+        for indexPathOfItemModelToDelete in (indexPathsOfItemModelsToDelete.sorted { $0 > $1 }) {
+          sectionModels[indexPathOfItemModelToDelete.section].deleteItemModel(
+            atIndex: indexPathOfItemModelToDelete.item)
+        }
+      }
+    } else {
+      for indexPathOfItemModelToDelete in (indexPathsOfItemModelsToDelete.sorted { $0 > $1 }) {
+        sectionModels[indexPathOfItemModelToDelete.section].deleteItemModel(
+          atIndex: indexPathOfItemModelToDelete.item)
+      }
     }
   }
 
@@ -750,18 +864,37 @@ final class ModelState {
     itemModelInsertIndexPathPairs: [(itemModel: ItemModel, insertIndexPath: IndexPath)])
   {
     // Always insert in ascending order
-    for (itemModel, insertIndexPath) in (itemModelInsertIndexPathPairs.sorted { $0.insertIndexPath < $1.insertIndexPath }) {
-      let sectionIndex = insertIndexPath.section
-      let itemIndex = insertIndexPath.item
-      let section = sectionModels[sectionIndex]
-      if itemIndex < section.numberOfItems, itemModel.id == section.idForItemModel(atIndex: itemIndex) {
-        // If the `itemModel` to insert already exists at the destination index, then there's no need to insert it again. This
-        // happens if item move updates are generated in addition to section move updates, which appears to be the case when using
-        // `UICollectionViewDiffableDataSource`. Other diffing approaches, like Paul Heckel's, do not produce item moves when
-        // their containing sections move.
-        continue
-      } else {
-        sectionModels[insertIndexPath.section].insert(itemModel, atIndex: itemIndex)
+    if MagazineLayout._enableExperimentalOptimizations {
+      sectionModels.withUnsafeMutableBufferPointer { sectionModels in
+        for (itemModel, insertIndexPath) in (itemModelInsertIndexPathPairs.sorted { $0.insertIndexPath < $1.insertIndexPath }) {
+          let sectionIndex = insertIndexPath.section
+          let itemIndex = insertIndexPath.item
+          let section = sectionModels[sectionIndex]
+          if itemIndex < section.numberOfItems, itemModel.id == section.idForItemModel(atIndex: itemIndex) {
+            // If the `itemModel` to insert already exists at the destination index, then there's no need to insert it again. This
+            // happens if item move updates are generated in addition to section move updates, which appears to be the case when using
+            // `UICollectionViewDiffableDataSource`. Other diffing approaches, like Paul Heckel's, do not produce item moves when
+            // their containing sections move.
+            continue
+          } else {
+            sectionModels[insertIndexPath.section].insert(itemModel, atIndex: itemIndex)
+          }
+        }
+      }
+    } else {
+      for (itemModel, insertIndexPath) in (itemModelInsertIndexPathPairs.sorted { $0.insertIndexPath < $1.insertIndexPath }) {
+        let sectionIndex = insertIndexPath.section
+        let itemIndex = insertIndexPath.item
+        let section = sectionModels[sectionIndex]
+        if itemIndex < section.numberOfItems, itemModel.id == section.idForItemModel(atIndex: itemIndex) {
+          // If the `itemModel` to insert already exists at the destination index, then there's no need to insert it again. This
+          // happens if item move updates are generated in addition to section move updates, which appears to be the case when using
+          // `UICollectionViewDiffableDataSource`. Other diffing approaches, like Paul Heckel's, do not produce item moves when
+          // their containing sections move.
+          continue
+        } else {
+          sectionModels[insertIndexPath.section].insert(itemModel, atIndex: itemIndex)
+        }
       }
     }
   }

--- a/MagazineLayout/LayoutCore/SectionModel.swift
+++ b/MagazineLayout/LayoutCore/SectionModel.swift
@@ -186,6 +186,14 @@ struct SectionModel {
   }
 
   @discardableResult
+  mutating func updateItemModel(atIndex indexOfUpdate: Int, to itemModel: ItemModel) -> ItemModel {
+    updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex: indexOfUpdate)
+    let oldItemModel = itemModels[indexOfUpdate]
+    itemModels[indexOfUpdate] = itemModel
+    return oldItemModel
+  }
+
+  @discardableResult
   mutating func deleteItemModel(atIndex indexOfDeletion: Int) -> ItemModel {
     updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex: indexOfDeletion)
 
@@ -198,12 +206,45 @@ struct SectionModel {
     itemModels.insert(itemModel, at: indexOfInsertion)
   }
 
-  mutating func updateMetrics(to metrics: MagazineLayoutSectionMetrics) {
-    guard self.metrics != metrics else { return }
+  @discardableResult
+  mutating func updateMetrics(to metrics: MagazineLayoutSectionMetrics) -> Bool {
+    guard self.metrics != metrics else { return false }
 
     self.metrics = metrics
 
     updateIndexOfFirstInvalidatedRowIfNecessary(toProposedIndex: 0)
+
+    return true
+  }
+
+  mutating func updateItemSizeModes(
+    _ sizeModeProvider: (_ itemIndex: Int) -> MagazineLayoutItemSizeMode)
+  {
+    guard numberOfItems > 0 else { return }
+
+    var indexOfFirstInvalidatedItem: Int?
+    itemModels.withUnsafeMutableBufferPointer { itemModels in
+      for index in 0..<itemModels.count {
+        let sizeMode = sizeModeProvider(index)
+        let itemModel = itemModels[index]
+        if itemModel.sizeMode != sizeMode {
+          itemModels[index].sizeMode = sizeMode
+          indexOfFirstInvalidatedItem = min(indexOfFirstInvalidatedItem ?? index, index)
+        }
+
+        if
+          case let .static(staticHeight) = sizeMode.heightMode,
+          itemModel.size.height != staticHeight
+        {
+          itemModels[index].size.height = staticHeight
+          indexOfFirstInvalidatedItem = min(indexOfFirstInvalidatedItem ?? index, index)
+        }
+      }
+    }
+
+    if let indexOfFirstInvalidatedItem {
+      updateIndexOfFirstInvalidatedRow(forChangeToItemAtIndex: indexOfFirstInvalidatedItem)
+    }
   }
 
   mutating func updateItemSizeMode(to sizeMode: MagazineLayoutItemSizeMode, atIndex index: Int) {

--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -104,9 +104,11 @@ public final class MagazineLayout: UICollectionViewLayout {
       let signpostID = OSSignpostID(log: signpostLog)
       os_signpost(.begin, log: signpostLog, name: SignpostName.prepareUpdateWidths, signpostID: signpostID)
 
-      for sectionIndex in 0..<modelState.numberOfSections {
-        let sectionMetrics = metricsForSection(atIndex: sectionIndex)
-        modelState.updateMetrics(to: sectionMetrics, forSectionAtIndex: sectionIndex)
+      modelState.forEachSectionModel { sectionIndex, sectionModel in
+        modelState.updateMetrics(
+          to: metricsForSection(atIndex: sectionIndex),
+          forSectionAtIndex: sectionIndex,
+          sectionModel: &sectionModel)
       }
 
       os_signpost(.end, log: signpostLog, name: SignpostName.prepareUpdateWidths, signpostID: signpostID)
@@ -117,38 +119,77 @@ public final class MagazineLayout: UICollectionViewLayout {
       let signpostID = OSSignpostID(log: signpostLog)
       os_signpost(.begin, log: signpostLog, name: SignpostName.prepareUpdateLayoutMetrics, signpostID: signpostID)
 
-      for sectionIndex in 0..<modelState.numberOfSections {
-        if Self._enableExperimentalOptimizations {
+      if MagazineLayout._enableExperimentalOptimizations {
+        modelState.forEachSectionModel { sectionIndex, sectionModel in
           reusableIndexPath.section = sectionIndex
-        }
 
-        let sectionMetrics = metricsForSection(atIndex: sectionIndex)
-        modelState.updateMetrics(to: sectionMetrics, forSectionAtIndex: sectionIndex)
+          modelState.updateMetrics(
+            to: metricsForSection(atIndex: sectionIndex),
+            forSectionAtIndex: sectionIndex,
+            sectionModel: &sectionModel)
 
-        if let headerModel = headerModelForHeader(inSectionAtIndex: sectionIndex) {
-          modelState.setHeader(headerModel, forSectionAtIndex: sectionIndex)
-        } else {
-          modelState.removeHeader(forSectionAtIndex: sectionIndex)
-        }
-
-        if let footerModel = footerModelForFooter(inSectionAtIndex: sectionIndex) {
-          modelState.setFooter(footerModel, forSectionAtIndex: sectionIndex)
-        } else {
-          modelState.removeFooter(forSectionAtIndex: sectionIndex)
-        }
-
-        if let backgroundModel = backgroundModelForBackground(inSectionAtIndex: sectionIndex) {
-          modelState.setBackground(backgroundModel, forSectionAtIndex: sectionIndex)
-        } else {
-          modelState.removeBackground(forSectionAtIndex: sectionIndex)
-        }
-
-        let numberOfItems = modelState.numberOfItems(inSectionAtIndex: sectionIndex)
-        for itemIndex in 0..<numberOfItems {
-          if Self._enableExperimentalOptimizations {
-            reusableIndexPath.item = itemIndex
-            modelState.updateItemSizeMode(to: sizeModeForItem(at: reusableIndexPath), forItemAt: reusableIndexPath)
+          if let headerModel = headerModelForHeader(inSectionAtIndex: sectionIndex) {
+            modelState.setHeader(
+              headerModel,
+              forSectionAtIndex: sectionIndex,
+              sectionModel: &sectionModel)
           } else {
+            modelState.removeHeader(forSectionAtIndex: sectionIndex, sectionModel: &sectionModel)
+          }
+
+          if let footerModel = footerModelForFooter(inSectionAtIndex: sectionIndex) {
+            modelState.setFooter(
+              footerModel,
+              forSectionAtIndex: sectionIndex,
+              sectionModel: &sectionModel)
+          } else {
+            modelState.removeFooter(forSectionAtIndex: sectionIndex, sectionModel: &sectionModel)
+          }
+
+          if let backgroundModel = backgroundModelForBackground(inSectionAtIndex: sectionIndex) {
+            modelState.setBackground(
+              backgroundModel,
+              forSectionAtIndex: sectionIndex,
+              sectionModel: &sectionModel)
+          } else {
+            modelState.removeBackground(
+              forSectionAtIndex: sectionIndex,
+              sectionModel: &sectionModel)
+          }
+
+          modelState.updateItemSizeModes(
+            forSectionAtIndex: sectionIndex,
+            sectionModel: &sectionModel)
+          { itemIndex in
+            reusableIndexPath.item = itemIndex
+            return sizeModeForItem(at: reusableIndexPath)
+          }
+        }
+      } else {
+        for sectionIndex in 0..<modelState.numberOfSections {
+          let sectionMetrics = metricsForSection(atIndex: sectionIndex)
+          modelState.updateMetrics(to: sectionMetrics, forSectionAtIndex: sectionIndex)
+
+          if let headerModel = headerModelForHeader(inSectionAtIndex: sectionIndex) {
+            modelState.setHeader(headerModel, forSectionAtIndex: sectionIndex)
+          } else {
+            modelState.removeHeader(forSectionAtIndex: sectionIndex)
+          }
+
+          if let footerModel = footerModelForFooter(inSectionAtIndex: sectionIndex) {
+            modelState.setFooter(footerModel, forSectionAtIndex: sectionIndex)
+          } else {
+            modelState.removeFooter(forSectionAtIndex: sectionIndex)
+          }
+
+          if let backgroundModel = backgroundModelForBackground(inSectionAtIndex: sectionIndex) {
+            modelState.setBackground(backgroundModel, forSectionAtIndex: sectionIndex)
+          } else {
+            modelState.removeBackground(forSectionAtIndex: sectionIndex)
+          }
+
+          let numberOfItems = modelState.numberOfItems(inSectionAtIndex: sectionIndex)
+          for itemIndex in 0..<numberOfItems {
             let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
             modelState.updateItemSizeMode(to: sizeModeForItem(at: indexPath), forItemAt: indexPath)
           }
@@ -171,6 +212,9 @@ public final class MagazineLayout: UICollectionViewLayout {
         verticalLayoutDirection: verticalLayoutDirection)
 
       var sections = [SectionModel]()
+      if Self._enableExperimentalOptimizations {
+        sections.reserveCapacity(currentCollectionView.numberOfSections)
+      }
       for sectionIndex in 0..<currentCollectionView.numberOfSections {
         if Self._enableExperimentalOptimizations {
           reusableIndexPath.section = sectionIndex
@@ -1164,7 +1208,9 @@ public final class MagazineLayout: UICollectionViewLayout {
   {
     let numberOfItems = currentCollectionView.numberOfItems(inSection: sectionIndex)
     var itemModels = [ItemModel]()
-    itemModels.reserveCapacity(numberOfItems)
+    if Self._enableExperimentalOptimizations {
+      itemModels.reserveCapacity(numberOfItems)
+    }
 
     for itemIndex in 0..<numberOfItems {
       if Self._enableExperimentalOptimizations {


### PR DESCRIPTION
## Details

Reduce some array overhead by using `UnsafeMutableBufferPointer` when batch-updating the `sectionModels` and `itemModels` arrays.

## How Has This Been Tested

Tested in demo app and Airbnb app. Additionally, all unit tests pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Perf fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
