### PR TITLE
Fix invalidation after horizontal insets change

### DIFF
--- a/MagazineLayout/Public/MagazineLayout.swift
+++ b/MagazineLayout/Public/MagazineLayout.swift
@@ -85,9 +85,10 @@ public final class MagazineLayout: UICollectionViewLayout {
     _currentCollectionView = collectionView
     _delegateMagazineLayout = currentCollectionView.delegate as? UICollectionViewDelegateMagazineLayout
 
-    // Save the previous collection view width if necessary
-    if prepareActions.contains(.cachePreviousWidth) {
+    // Save the previous collection view width and horizontal insets if necessary
+    if prepareActions.contains(.cachePreviousHorizontalMetrics) {
       cachedCollectionViewWidth = currentCollectionView.bounds.width
+      cachedHorizontalContentInset = contentInset.left + contentInset.right
     }
 
     if
@@ -905,14 +906,19 @@ public final class MagazineLayout: UICollectionViewLayout {
       prepareActions.formUnion(.recreateSectionModels)
     }
 
-    // Checking `cachedCollectionViewWidth != collectionView?.bounds.size.width` is necessary
-    // because the collection view's width can change without a `contentSizeAdjustment` occurring.
+    // Manually checking for a different width or different horizontal insets is necessary because
+    // these values can change without a `contentSizeAdjustment` occurring.
     let isSameWidth = collectionView?.bounds.size.width.isEqual(
       to: cachedCollectionViewWidth ?? -.greatestFiniteMagnitude,
       screenScale: scale)
       ?? false
-    if !isSameWidth {
-      prepareActions.formUnion(.cachePreviousWidth)
+    let horizontalContentInset = (collectionView?.adjustedContentInset.left ?? 0) +
+      (collectionView?.adjustedContentInset.right ?? 0)
+    let isSameHorizontalContentInset = horizontalContentInset.isEqual(
+      to: cachedHorizontalContentInset ?? -.greatestFiniteMagnitude,
+      screenScale: scale)
+    if !isSameWidth || !isSameHorizontalContentInset {
+      prepareActions.formUnion(.cachePreviousHorizontalMetrics)
       prepareActions.formUnion(.updateLayoutMetrics)
     }
 
@@ -994,7 +1000,7 @@ public final class MagazineLayout: UICollectionViewLayout {
 
     static let recreateSectionModels = PrepareActions(rawValue: 1 << 0)
     static let updateLayoutMetrics = PrepareActions(rawValue: 1 << 1)
-    static let cachePreviousWidth = PrepareActions(rawValue: 1 << 2)
+    static let cachePreviousHorizontalMetrics = PrepareActions(rawValue: 1 << 2)
   }
   private var prepareActions: PrepareActions = []
 
@@ -1004,6 +1010,7 @@ public final class MagazineLayout: UICollectionViewLayout {
   private var hasDataSourceCountInvalidationBeforeReceivingUpdateItems = false
 
   private var cachedCollectionViewWidth: CGFloat?
+  private var cachedHorizontalContentInset: CGFloat?
   private var previousContentInset: UIEdgeInsets?
 
   // Unowned unsafe references to avoid weak reference overhead.


### PR DESCRIPTION
## Details

When the new experimental optimizations are enabled, we default to invalidating less often. This revealed a case that should have been handled before - if the width _or the horizontal insets change_, we must invalidate layout metrics the next time prepare runs. Previously, we were only invalidating if the width changed.

This would be a good candidate for a unit test once I add tests for the layout object.

## How Has This Been Tested

Airbnb app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
